### PR TITLE
fix(frontend): 品目追加時のUIフィードバックを改善

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ function App() {
     e.preventDefault();
     if (!newItemName || !newItemUnit) return;
 
+    setLoading(true);
     try {
       const response = await fetch(`${API_BASE_URL}/items`, {
         method: "POST",
@@ -39,10 +40,16 @@ function App() {
       if (response.ok) {
         setNewItemName("");
         setNewItemUnit("");
-        fetchItems();
+        await fetchItems();
+      } else {
+        const data = await response.json();
+        alert(`追加に失敗しました: ${data.message || response.statusText}`);
       }
     } catch (error) {
       console.error("Error adding item:", error);
+      alert("通信エラーが発生しました。");
+    } finally {
+      setLoading(false);
     }
   };
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -61,6 +61,31 @@ describe('App', () => {
     });
   });
 
+  it('shows error alert when adding an item fails', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Internal Server Error',
+      json: async () => ({ message: 'Something went wrong' }),
+    });
+
+    fireEvent.change(screen.getByPlaceholderText('品目名（例: トイレットペーパー）'), { target: { value: 'Tissue' } });
+    fireEvent.change(screen.getByPlaceholderText('単位（例: ロール, パック）'), { target: { value: 'packs' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('追加に失敗しました: Something went wrong'));
+    });
+  });
+
   it('can update stock', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
設計:
- 選定内容: addItem関数にloading状態の制御とエラーハンドリング（alert表示）を追加
- 却下内容: Toast通知の実装（既存のApp.jsxにUIライブラリが導入されていないため、シンプルさを優先してalertを採用）
- 理由: ユーザーが追加ボタンを押した際に反応がないと感じる問題を解決するため、ローディング表示とエラー時の明示的な通知が必要。

影響:
- 影響モジュール: App.jsx
- 振る舞いの変更: 品目追加中にスピナーが表示され、失敗時にはアラートが表示されるようになる。

テスト:
- 追加済み: 異常系（追加失敗時）のテストケースを追加。
- 未追加: N/A