### PR TITLE
fix(backend): API GatewayでのCORSエラーを修正

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,6 +4,8 @@ provider:
   name: aws
   runtime: nodejs18.x
   region: ap-northeast-1
+  httpApi:
+    cors: true
   environment:
     TABLE_NAME: ${self:custom.tableName}
     STOCK_HISTORY_TABLE_NAME: ${self:custom.stockHistoryTableName}


### PR DESCRIPTION
設計:
- 選定内容: serverless.ymlのproviderセクションにhttpApi: cors: trueを追加
- 却下内容: Lambdaハンドラー内での追加のCORSヘッダー実装（既にhandler.jsで*ヘッダーを返しているが、OPTIONSリクエストがAPI Gatewayレベルで拒否されているため）
- 理由: フロントエンドからのOPTIONSリクエストが403 Forbiddenで失敗しており、API GatewayレベルでのCORS設定が不足していると判断したため。

影響:
- 影響モジュール: serverless.yml
- 振る舞いの変更: API GatewayがOPTIONSリクエストに対して適切に応答し、ブラウザからのクロスオリジンリクエストが許可されるようになる。

テスト:
- 追加済み: N/A (インフラ設定変更のため)
- 未追加: N/A