### PR TITLE
feat(ui): 品目追加フォームを在庫一覧の最下部に移動

### DIFF
--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -114,42 +114,6 @@ function Home() {
 
       <main>
         <section className="mb-5">
-          <div className="card shadow-sm border-0">
-            <div className="card-body p-4">
-              <h2 className="h5 mb-4 d-flex align-items-center">
-                <Plus size={20} className="me-2 text-primary" />
-                新しい品目を追加
-              </h2>
-              <form onSubmit={addItem} className="row g-3">
-                <div className="col-md-5">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="品目名（例: トイレットペーパー）"
-                    value={newItemName}
-                    onChange={(e) => setNewItemName(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="col-md-4">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="単位（例: ロール, パック）"
-                    value={newItemUnit}
-                    onChange={(e) => setNewItemUnit(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="col-md-3">
-                  <button type="submit" className="btn btn-primary w-100">追加</button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </section>
-
-        <section>
           <h2 className="h5 mb-4">在庫一覧</h2>
           {loading ? (
             <div className="text-center py-5">
@@ -236,6 +200,42 @@ function Home() {
               )}
             </div>
           )}
+        </section>
+
+        <section className="mt-5">
+          <div className="card shadow-sm border-0">
+            <div className="card-body p-4">
+              <h2 className="h5 mb-4 d-flex align-items-center">
+                <Plus size={20} className="me-2 text-primary" />
+                新しい品目を追加
+              </h2>
+              <form onSubmit={addItem} className="row g-3">
+                <div className="col-md-5">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="品目名（例: トイレットペーパー）"
+                    value={newItemName}
+                    onChange={(e) => setNewItemName(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="col-md-4">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="単位（例: ロール, パック）"
+                    value={newItemUnit}
+                    onChange={(e) => setNewItemUnit(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="col-md-3">
+                  <button type="submit" className="btn btn-primary w-100">追加</button>
+                </div>
+              </form>
+            </div>
+          </div>
         </section>
       </main>
     </div>


### PR DESCRIPTION
設計:
- 選定内容: 新規品目追加フォームの配置変更
- 却下内容: フォームのスタイル変更（今回は配置のみ変更）
- 理由: ユーザーからの「最下部に表示して」という要望に応えるため

影響:
- 影響モジュール: Home.jsx
- 振る舞いの変更: ページ上部にあった「新しい品目を追加」セクションが、在庫一覧の下に移動した。

テスト:
- 追加済み: N/A (既存のApp.test.jsxで機能が維持されていることを確認)
- 未追加: N/A