### PR TITLE
fix(deploy): DynamoDBテーブル名の変更によるデプロイエラーの解消

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -25,8 +25,8 @@ provider:
 
 custom:
   appName: uchi-stock-app
-  tableName: ${self:custom.appName}-items
-  stockHistoryTableName: ${self:custom.appName}-stock-history
+  tableName: ${self:custom.appName}-items-v2
+  stockHistoryTableName: ${self:custom.appName}-stock-history-v2
   cognitoUserPoolArn: ${env:COGNITO_USER_POOL_ARN, 'arn:aws:cognito-idp:ap-northeast-1:123456789012:userpool/ap-northeast-1_example'}
 
 functions:


### PR DESCRIPTION
設計:
- 選定内容: DynamoDBテーブル名に -v2 を付与し、リソースの再作成を許可。
- 却下内容: 既存テーブルのキー構造変更（不可能）。スタックの手動削除。
- 理由: パーティションキーの変更（itemId -> userId）はDynamoDBの仕様上置換が必要だが、カスタム名が指定されている場合はCloudFormationが自動置換できないため、名前を変更して新規作成を促す。

影響:
- 影響モジュール: インフラ（DynamoDB）。
- 振る舞いの変更: 新しいテーブルが作成される。既存のデータは -v2 の付いた新しいテーブルには引き継がれない。

テスト:
- 追加済み: N/A (テーブル名変更後もバックエンドテストがパスすることを確認)
- 未追加: 実際のデプロイテスト（CI環境で実施）。