### PR TITLE
fix(backend): CORS設定に x-user-id ヘッダーを追加

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -36,56 +36,128 @@ functions:
       - http:
           path: items
           method: post
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   getItems:
     handler: handler.getItems
     events:
       - http:
           path: items
           method: get
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   updateItem:
     handler: handler.updateItem
     events:
       - http:
           path: items/{itemId}
           method: put
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   deleteItem:
     handler: handler.deleteItem
     events:
       - http:
           path: items/{itemId}
           method: delete
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   addStock:
     handler: handler.addStock
     events:
       - http:
           path: items/{itemId}/stock
           method: post
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   consumeStock:
     handler: handler.consumeStock
     events:
       - http:
           path: items/{itemId}/consume
           method: post
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   getConsumptionHistory:
     handler: handler.getConsumptionHistory
     events:
       - http:
           path: items/{itemId}/history
           method: get
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
   getEstimatedDepletionDate:
     handler: handler.getEstimatedDepletionDate
     events:
       - http:
           path: items/{itemId}/estimate
           method: get
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
 
 resources:
   Resources:


### PR DESCRIPTION
設計:
- 選定内容: serverless.yml の CORS 設定において headers リストに x-user-id を追加。
- 却下内容: すべてのヘッダーをワイルドカードで許可する設定（セキュリティ上の懸念）。
- 理由: フロントエンドがカスタムヘッダー x-user-id を使用しており、CORS プリフライトリクエストで許可される必要があるため。

影響:
- 影響モジュール: Backend API (Serverless/API Gateway)
- 振る舞いの変更: ブラウザからのカスタムヘッダーを含むリクエストが正常に受理されるようになる。

テスト:
- 追加済み: N/A (既存のユニットテストが通過することを確認)
- 未追加: 統合テスト環境での動作確認。