### PR TITLE
fix(auth): Googleログイン設定の修正とバリデーションの強化

### DIFF
--- a/frontend/src/authConfig.js
+++ b/frontend/src/authConfig.js
@@ -8,7 +8,7 @@ const authConfig = {
       loginWith: {
         oauth: {
           domain: import.meta.env.VITE_AUTH_DOMAIN || '',
-          scopes: ['email', 'profile', 'openid'],
+          scopes: ['email', 'profile', 'openid', 'aws.cognito.signin.user.admin'],
           redirectSignIn: [import.meta.env.VITE_REDIRECT_SIGN_IN || 'http://localhost:5173'],
           redirectSignOut: [import.meta.env.VITE_REDIRECT_SIGN_OUT || 'http://localhost:5173'],
           responseType: 'code',
@@ -20,9 +20,9 @@ const authConfig = {
 };
 
 export const configureAmplify = () => {
-  if (authConfig.Auth.Cognito.userPoolId) {
+  if (authConfig.Auth.Cognito.userPoolId && authConfig.Auth.Cognito.userPoolClientId) {
     Amplify.configure(authConfig);
   } else {
-    console.warn('Amplify is not configured. Google SSO will not work without environment variables.');
+    console.warn('Amplify is not configured. userPoolId or userPoolClientId is missing.');
   }
 };


### PR DESCRIPTION
設計:
- 選定内容: Amplify.configure の呼び出し条件に userPoolClientId を追加し、OAuthスコープに aws.cognito.signin.user.admin を追加
- 却下内容: エラーハンドリングの完全な変更（今回は設定不備の解消を優先）
- 理由: ユーザーが報告した AuthUserPoolException は設定不足が原因であり、特に Client ID の欠落やスコープ不足が遷移を妨げる可能性があるため。

影響:
- 影響モジュール: frontend/src/authConfig.js
- 振る舞いの変更: 環境変数が不足している場合に警告が表示されるようになり、設定が不完全な状態での Amplify の初期化を防ぐ。

テスト:
- 追加済み: N/A (既存の App.test.jsx がパスすることを確認)
- 未追加: SSOプロバイダーとの連携テスト（モック環境では困難なため）