### PR TITLE
feat(release): ローカル環境でのSemantic Release実行に対応

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
-  branches: ["release"],
-  repositoryUrl: "https://github.com/bamiyanapp/karuta.git",
+  branches: ["main", "release"],
+  repositoryUrl: "https://github.com/bamiyanapp/uchi-stock.git",
   plugins: [
     [
       "@semantic-release/commit-analyzer",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,33 @@ graph TD
 
 詳細な CI/CD パイプラインの仕様については、[CI/CD Pipeline Specification](docs/cicd-pipeline-specification.md) を参照してください。
 
+## リリース
+
+このプロジェクトは `semantic-release` を使用して自動リリース管理を行っています。
+
+### ローカルでのリリース実行
+
+GitHub Actions を介さずにローカル環境からリリースノートの作成とプッシュを行うことができます。
+
+#### 準備
+1. GitHub で Personal Access Token (classic) を作成します。
+   - スコープ: `repo` が必要です。
+2. プロジェクトルートに `.env` ファイルを作成し、トークンを設定します。
+   ```env
+   GITHUB_TOKEN=ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+   ```
+
+#### 実行
+1. リリースの内容を事前に確認する（ドライラン）:
+   ```bash
+   npm run release:local -- --dry-run
+   ```
+2. 実際にリリースを実行する:
+   ```bash
+   npm run release:local
+   ```
+   ※ このコマンドにより、タグの作成、GitHub Release の作成、`CHANGELOG.md` の更新、およびそれらのプッシュが自動的に行われます。
+
 ## 運用
 
 ### バックアップと復旧

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "js-yaml": "^4.1.1",
     "semantic-release": "^25.0.2"
   },
+  "scripts": {
+    "release:local": "./scripts/local-release.sh"
+  },
   "version": "1.12.1"
 }

--- a/scripts/local-release.sh
+++ b/scripts/local-release.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# .envファイルがあれば読み込む
+if [ -f .env ]; then
+  export $(cat .env | xargs)
+fi
+
+# GITHUB_TOKENの確認
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: GITHUB_TOKEN environment variable is not set."
+  echo "Please set it in your environment or in a .env file."
+  exit 1
+fi
+
+# 引数の処理
+DRY_RUN=""
+if [ "$1" == "--dry-run" ]; then
+  DRY_RUN="--dry-run"
+  echo "Running in dry-run mode..."
+fi
+
+# semantic-releaseの実行
+# --no-ci: CI環境でなくても実行可能にする
+npx semantic-release --no-ci $DRY_RUN


### PR DESCRIPTION
設計:
- 選定内容: scripts/local-release.sh の作成、.releaserc.cjs の修正、package.json へのスクリプト追加
- 却下内容: CI環境でのみ実行する制限の維持
- 理由: ユーザーがローカルから手動でリリースを行いたいという要件に対応するため

影響:
- 影響モジュール: release プロセス
- 振る舞いの変更: npm run release:local を実行することで、ローカルからGitHubへのリリースとCHANGELOGのプッシュが可能になった

テスト:
- 追加済み: scripts/local-release.sh のドライラン実行（トークン未設定時のエラー確認）
- 未追加: 実際のトークンを使用したGitHubへのプッシュ（環境依存のため）