### PR TITLE
fix(ci): 自動マージ前にベースブランチの更新を取り込むように改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,18 @@ jobs:
             const branchName = context.payload.pull_request.head.ref;
             console.log(`Attempting to merge PR #${prNumber}`);
             try {
+              // ベースブランチが更新されている場合に備えて最新化を試みる
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                console.log(`Updated branch for PR #${prNumber}`);
+              } catch (updateError) {
+                console.log(`Note: Could not update branch (maybe already up to date): ${updateError.message}`);
+              }
+
               await github.rest.pulls.merge({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -104,6 +116,9 @@ jobs:
               });
               console.log(`Successfully merged PR #${prNumber}`);
             } catch (error) {
+              if (error.message.includes("is not mergeable")) {
+                console.error(`PR #${prNumber} is not mergeable (conflicts or status checks failed).`);
+              }
               console.error(`Failed to merge PR #${prNumber}:`, error.message);
               throw error;
             }


### PR DESCRIPTION
設計:
- 選定内容: .github/workflows/ci.yml の merge ジョブに github.rest.pulls.updateBranch の呼び出しを追加
- 却下内容: マージ失敗時に単にエラーで終了するだけの現在の実装
- 理由: ベースブランチが更新されたことによるマージ失敗を自動的に解消し、CIの完走率を高めるため

影響:
- 影響モジュール: CI ワークフロー
- 振る舞いの変更: PRの自動マージ実行前にベースブランチが最新でない場合、自動的にマージ（またはリベース）が試みられる

テスト:
- 追加済み: N/A (CI上の動作改善のため)
- 未追加: 実際の競合発生時の挙動確認（環境依存のため）