### PR TITLE
feat(db): stock-historyのパーティションキーをitemIdに変更

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -356,7 +356,6 @@ exports.getConsumptionHistory = async (event) => {
     const { itemId } = event.pathParameters;
     const { Items } = await docClient.send(new QueryCommand({
       TableName: HISTORY_TABLE,
-      IndexName: "ItemIdIndex",
       KeyConditionExpression: "itemId = :itemId",
       FilterExpression: "userId = :userId",
       ExpressionAttributeValues: { ":itemId": itemId, ":userId": userId },
@@ -412,7 +411,6 @@ exports.getEstimatedDepletionDate = async (event) => {
     // 消費履歴を取得して平均消費速度を計算
     const { Items: history } = await docClient.send(new QueryCommand({
       TableName: HISTORY_TABLE,
-      IndexName: "ItemIdIndex",
       KeyConditionExpression: "itemId = :itemId",
       FilterExpression: "#t = :type AND userId = :userId",
       ExpressionAttributeNames: { "#t": "type" },

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -134,7 +134,7 @@ describe('Household Items API', () => {
 
   describe('getConsumptionHistory', () => {
     it('should return history successfully', async () => {
-      const mockHistory = [{ historyId: 'h1', itemId: 'item-1', type: 'consumption' }];
+      const mockHistory = [{ historyId: 'h1', itemId: 'item-1', type: 'consumption', date: '2023-01-01T12:00:00Z', userId: TEST_USER }];
       ddbMock.on(QueryCommand).resolves({ Items: mockHistory });
 
       const result = await getConsumptionHistory({ 
@@ -152,8 +152,8 @@ describe('Household Items API', () => {
       ddbMock.on(GetCommand).resolves({ Item: { userId: TEST_USER, itemId: 'item-1', currentStock: 10 } });
       ddbMock.on(QueryCommand).resolves({ 
         Items: [
-          { date: '2023-01-01T12:00:00Z', quantity: 2, type: 'consumption' },
-          { date: '2023-01-03T12:00:00Z', quantity: 2, type: 'consumption' }
+          { date: '2023-01-01T12:00:00Z', quantity: 2, type: 'consumption', userId: TEST_USER },
+          { date: '2023-01-03T12:00:00Z', quantity: 2, type: 'consumption', userId: TEST_USER }
         ]
       });
 
@@ -177,8 +177,8 @@ describe('Household Items API', () => {
       ddbMock.on(GetCommand).resolves({ Item: { userId: TEST_USER, itemId: 'item-1', currentStock: 10 } });
       ddbMock.on(QueryCommand).resolves({ 
         Items: [
-          { date: 'invalid-date', quantity: 2, type: 'consumption' },
-          { date: '2023-01-03T12:00:00Z', quantity: 2, type: 'consumption' }
+          { date: 'invalid-date', quantity: 2, type: 'consumption', userId: TEST_USER },
+          { date: '2023-01-03T12:00:00Z', quantity: 2, type: 'consumption', userId: TEST_USER }
         ]
       });
 
@@ -195,11 +195,10 @@ describe('Household Items API', () => {
 
     it('should handle NaN in calculations gracefully', async () => {
         ddbMock.on(GetCommand).resolves({ Item: { userId: TEST_USER, itemId: 'item-1', currentStock: 10 } });
-        // 同一時刻の記録が複数ある場合など、daysDiffが非常に小さくなるケースのシミュレーション
         ddbMock.on(QueryCommand).resolves({ 
           Items: [
-            { date: '2023-01-01T12:00:00Z', quantity: 2, type: 'consumption' },
-            { date: '2023-01-01T12:00:00Z', quantity: 2, type: 'consumption' }
+            { date: '2023-01-01T12:00:00Z', quantity: 2, type: 'consumption', userId: TEST_USER },
+            { date: '2023-01-01T12:00:00Z', quantity: 2, type: 'consumption', userId: TEST_USER }
           ]
         });
   

--- a/backend/seed-stock.js
+++ b/backend/seed-stock.js
@@ -64,7 +64,7 @@ async function clearTables() {
   for (const item of historyData.Items || []) {
     await docClient.send(new DeleteCommand({ 
       TableName: HISTORY_TABLE, 
-      Key: { userId: item.userId, historyId: item.historyId } 
+      Key: { itemId: item.itemId, date: item.date } 
     }));
   }
   

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -183,8 +183,6 @@ resources:
       Properties:
         TableName: ${self:custom.stockHistoryTableName}
         AttributeDefinitions:
-          - AttributeName: historyId
-            AttributeType: S
           - AttributeName: userId
             AttributeType: S
           - AttributeName: itemId
@@ -192,14 +190,14 @@ resources:
           - AttributeName: date
             AttributeType: S
         KeySchema:
-          - AttributeName: userId
+          - AttributeName: itemId
             KeyType: HASH
-          - AttributeName: historyId
+          - AttributeName: date
             KeyType: RANGE
         GlobalSecondaryIndexes:
-          - IndexName: ItemIdIndex
+          - IndexName: UserIdIndex
             KeySchema:
-              - AttributeName: itemId
+              - AttributeName: userId
                 KeyType: HASH
               - AttributeName: date
                 KeyType: RANGE


### PR DESCRIPTION
設計:
- 選定内容: StockHistoryTableのパーティションキーをuserIdからitemIdに変更
- 却下内容: userIdをパーティションキーとし続ける旧構造
- 理由: アイテムごとの履歴取得効率を向上させるため。またユーザーからの明示的な修正依頼に基づき実施。

影響:
- 影響モジュール: backend/serverless.yml, backend/handler.js, backend/seed-stock.js, backend/handler.test.js
- 振る舞いの変更: 履歴データの保存・取得時にitemIdを主要なキーとして扱うようになる

テスト:
- 追加済み: backend/handler.test.js を新構造に合わせて更新・パス確認済み
- 未追加: N/A