### PR TITLE
feat: redesign stock management screen to focus on remaining estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ graph TD
 graph TD
     Login[Google ログイン画面] --> |ログイン成功| Home[在庫一覧画面]
     Home --> |品目名をクリック| Detail[品目詳細・履歴画面]
+    Home --> |「在庫を更新する」をクリック| Update[在庫更新画面]
+    Detail --> |「在庫を更新する」をクリック| Update
+    Update --> |「更新を保存する」をクリック| Detail
     Detail --> |「在庫一覧へ戻る」をクリック| Home
     Home --> |ログアウト| Login
 ```
@@ -82,9 +85,9 @@ graph TD
 
 | 関数名 | パス | メソッド | 説明 |
 | :--- | :--- | :--- | :--- |
-| createItem | `/items` | POST | 新しい品目を登録する。 |
+| createItem | `/items` | POST | 新しい品目を登録する。（管理用） |
 | getItems | `/items` | GET | 登録されているすべての品目を取得する。 |
-| updateItem | `/items/{itemId}` | PUT | 品目情報を更新する。 |
+| updateItem | `/items/{itemId}` | PUT | 品目情報を更新する。（管理用） |
 | deleteItem | `/items/{itemId}` | DELETE | 品目を削除する。 |
 | addStock | `/items/{itemId}/stock` | POST | 品目の在庫を追加する。 |
 | consumeStock | `/items/{itemId}/consume` | POST | 品目の在庫を消費する。 |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./components/Home";
 import ItemDetail from "./components/ItemDetail";
+import StockUpdate from "./components/StockUpdate";
 import { UserProvider } from "./contexts/UserContext";
 import "./App.css";
 
@@ -11,6 +12,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/item/:itemId" element={<ItemDetail />} />
+          <Route path="/item/:itemId/update" element={<StockUpdate />} />
         </Routes>
       </Router>
     </UserProvider>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -26,6 +26,10 @@ describe('App', () => {
     vi.clearAllMocks();
   });
 
+  const mockItems = [
+    { itemId: '1', name: 'Toilet Paper', unit: 'rolls', currentStock: 5, updatedAt: new Date().toISOString() }
+  ];
+
   it('renders household items management screen initially', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('/estimate')) {
@@ -34,12 +38,13 @@ describe('App', () => {
           json: async () => ({ estimatedDepletionDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString() }),
         };
       }
-      return {
-        ok: true,
-        json: async () => [
-          { itemId: '1', name: 'Toilet Paper', unit: 'rolls', currentStock: 5, updatedAt: new Date().toISOString() }
-        ],
-      };
+      if (url.includes('/items')) {
+        return {
+          ok: true,
+          json: async () => mockItems,
+        };
+      }
+      return { ok: true, json: async () => ({}) };
     });
 
     await act(async () => {
@@ -49,123 +54,51 @@ describe('App', () => {
     expect(screen.getByText('家庭用品在庫管理')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText('Toilet Paper')).toBeInTheDocument();
-      expect(screen.getByText('5')).toBeInTheDocument();
-      expect(screen.getByText('rolls')).toBeInTheDocument();
-      expect(screen.getByText(/時点の在庫/)).toBeInTheDocument();
-      expect(screen.getByText(/あと5日で在庫切れの予想/)).toBeInTheDocument();
     });
   });
 
-  it('can add a new item', async () => {
-    fetch.mockImplementation(async (url, options) => {
-      if (options?.method === 'POST') {
-        return { ok: true, json: async () => ({}) };
+  it('can navigate to update page and submit', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/estimate')) return { ok: true, json: async () => ({}) };
+      if (url.includes('/items')) {
+        return {
+          ok: true,
+          json: async () => mockItems,
+        };
       }
-      return {
-        ok: true,
-        json: async () => [],
-      };
+      return { ok: true, json: async () => ({}) };
     });
 
     await act(async () => {
       render(<App />);
     });
 
-    fireEvent.change(screen.getByPlaceholderText('品目名（例: トイレットペーパー）'), { target: { value: 'Tissue' } });
-    fireEvent.change(screen.getByPlaceholderText('単位（例: ロール, パック）'), { target: { value: 'packs' } });
-    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+    // Home 画面の「在庫を更新する」ボタン
+    const updateLinks = await screen.findAllByText('在庫を更新する');
+    fireEvent.click(updateLinks[0]);
 
+    // StockUpdate 画面への遷移を待機
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/items'), expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ name: 'Tissue', unit: 'packs' })
-      }));
-    });
-  });
-
-  it('shows error alert when adding an item fails', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
+      expect(screen.getByText('在庫を更新する')).toBeInTheDocument();
     });
 
-    await act(async () => {
-      render(<App />);
-    });
-
-    fetch.mockResolvedValueOnce({
-      ok: false,
-      statusText: 'Internal Server Error',
-      json: async () => ({ message: 'Something went wrong' }),
-    });
-
-    fireEvent.change(screen.getByPlaceholderText('品目名（例: トイレットペーパー）'), { target: { value: 'Tissue' } });
-    fireEvent.change(screen.getByPlaceholderText('単位（例: ロール, パック）'), { target: { value: 'packs' } });
-    fireEvent.click(screen.getByRole('button', { name: '追加' }));
-
-    await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('追加に失敗しました: Something went wrong'));
-    });
-  });
-
-  it('can update stock using buttons', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [
-        { itemId: '1', name: 'Toilet Paper', unit: 'rolls', currentStock: 5, updatedAt: new Date().toISOString() }
-      ],
-    });
-
-    await act(async () => {
-      render(<App />);
-    });
+    const inputs = screen.getAllByRole('spinbutton');
+    fireEvent.change(inputs[0], { target: { value: '2' } });
+    fireEvent.change(inputs[1], { target: { value: '1' } });
 
     fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
 
-    const consumeBtn = screen.getByTitle('消費');
-    fireEvent.click(consumeBtn);
+    fireEvent.click(screen.getByText('更新を保存する'));
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/items/1/consume'), expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ quantity: 1 })
+        method: "POST",
+        body: JSON.stringify({ quantity: 2, memo: "" })
       }));
-    });
-
-    const purchaseBtn = screen.getByTitle('購入');
-    fireEvent.click(purchaseBtn);
-
-    await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/items/1/stock'), expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ quantity: 1 })
+        method: "POST",
+        body: JSON.stringify({ quantity: 1, memo: "" })
       }));
-    });
-  });
-
-  it('can navigate to detail page', async () => {
-    fetch.mockImplementation(async (url) => {
-      if (url.includes('/history')) return { ok: true, json: async () => [] };
-      if (url.includes('/estimate')) return { ok: true, json: async () => ({}) };
-      return {
-        ok: true,
-        json: async () => [
-          { itemId: '1', name: 'Toilet Paper', unit: 'rolls', currentStock: 5, updatedAt: new Date().toISOString() }
-        ],
-      };
-    });
-
-    await act(async () => {
-      render(<App />);
-    });
-
-    const detailLink = await screen.findByText('詳細・履歴を見る');
-    fireEvent.click(detailLink);
-
-    await waitFor(() => {
-      expect(screen.getByText('在庫一覧へ戻る')).toBeInTheDocument();
-      expect(screen.getByText('在庫推定')).toBeInTheDocument();
-      expect(screen.getByText('履歴詳細')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/ItemDetail.jsx
+++ b/frontend/src/components/ItemDetail.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
-import { ArrowLeft, Package, History as HistoryIcon, TrendingDown, Minus, Plus } from "lucide-react";
+import { ArrowLeft, Package, History as HistoryIcon, TrendingDown, Minus, Plus, Edit } from "lucide-react";
 import { useUser } from "../contexts/UserContext";
 
 const API_BASE_URL = "https://b974xlcqia.execute-api.ap-northeast-1.amazonaws.com/dev";
@@ -11,7 +11,6 @@ const ItemDetail = () => {
   const [item, setItem] = useState(null);
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
   const [estimate, setEstimate] = useState(null);
   const { userId, idToken } = useUser();
 
@@ -56,29 +55,6 @@ const ItemDetail = () => {
 
     initialFetch();
   }, [fetchData]);
-
-  const handleQuickUpdate = async (type) => {
-    setSubmitting(true);
-    try {
-      const endpoint = type === "purchase" ? "stock" : "consume";
-      const response = await fetch(`${API_BASE_URL}/items/${itemId}/${endpoint}`, {
-        method: "POST",
-        headers: { 
-          ...getHeaders(),
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({ quantity: 1 }),
-      });
-
-      if (response.ok) {
-        await fetchData();
-      }
-    } catch (error) {
-      console.error(`Error updating stock (${type}):`, error);
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   if (loading) {
     return (
@@ -148,20 +124,12 @@ const ItemDetail = () => {
           </div>
           <div className="col-md-6">
             <div className="d-flex gap-2 justify-content-md-end">
-              <button 
-                onClick={() => handleQuickUpdate("consumption")}
-                disabled={submitting || item.currentStock <= 0}
-                className="btn btn-outline-warning d-inline-flex align-items-center px-4 py-2"
-              >
-                <Minus size={20} className="me-2" /> 消費
-              </button>
-              <button 
-                onClick={() => handleQuickUpdate("purchase")}
-                disabled={submitting}
+              <Link 
+                to={`/item/${itemId}/update`}
                 className="btn btn-primary d-inline-flex align-items-center px-4 py-2"
               >
-                <Plus size={20} className="me-2" /> 購入
-              </button>
+                <Edit size={20} className="me-2" /> 在庫を更新する
+              </Link>
             </div>
           </div>
         </div>

--- a/frontend/src/components/StockUpdate.jsx
+++ b/frontend/src/components/StockUpdate.jsx
@@ -1,0 +1,252 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { ArrowLeft, Save, Minus, Plus, Calendar } from "lucide-react";
+import { useUser } from "../contexts/UserContext";
+
+const API_BASE_URL = "https://b974xlcqia.execute-api.ap-northeast-1.amazonaws.com/dev";
+
+const StockUpdate = () => {
+  const { itemId } = useParams();
+  const navigate = useNavigate();
+  const { userId, idToken } = useUser();
+  const [item, setItem] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  
+  const [consumption, setConsumption] = useState(0);
+  const [purchase, setPurchase] = useState(0);
+  const [memo, setMemo] = useState("");
+
+  const getHeaders = useCallback(() => {
+    const headers = {
+      "x-user-id": userId
+    };
+    if (idToken) {
+      headers["Authorization"] = `Bearer ${idToken}`;
+    }
+    return headers;
+  }, [userId, idToken]);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const headers = getHeaders();
+      const response = await fetch(`${API_BASE_URL}/items`, { headers });
+      const itemsData = await response.json();
+      const currentItem = itemsData.find(i => i.itemId === itemId);
+      setItem(currentItem);
+    } catch (error) {
+      console.error("Error fetching item details:", error);
+    }
+  }, [itemId, getHeaders]);
+
+  useEffect(() => {
+    const initialFetch = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    initialFetch();
+  }, [fetchData]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (consumption === 0 && purchase === 0) {
+      alert("消費量または購入数を入力してください。");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const headers = {
+        ...getHeaders(),
+        "Content-Type": "application/json"
+      };
+
+      // 消費の登録
+      if (consumption > 0) {
+        await fetch(`${API_BASE_URL}/items/${itemId}/consume`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ quantity: consumption, memo }),
+        });
+      }
+
+      // 購入の登録
+      if (purchase > 0) {
+        await fetch(`${API_BASE_URL}/items/${itemId}/stock`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ quantity: purchase, memo }),
+        });
+      }
+
+      navigate(`/item/${itemId}`);
+    } catch (error) {
+      console.error("Error updating stock:", error);
+      alert("更新に失敗しました。");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="container py-5 text-center">
+        <div className="spinner-border text-primary" role="status">
+          <span className="visually-hidden">読み込み中...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!item) {
+    return (
+      <div className="container py-5 text-center">
+        <h2>品目が見つかりませんでした。</h2>
+        <Link to="/" className="btn btn-primary mt-3">戻る</Link>
+      </div>
+    );
+  }
+
+  const daysSinceUpdate = Math.floor((new Date() - new Date(item.updatedAt)) / (1000 * 60 * 60 * 24));
+
+  return (
+    <div className="container py-5">
+      <div className="mb-4">
+        <Link to={`/item/${itemId}`} className="btn btn-link p-0 text-decoration-none d-inline-flex align-items-center">
+          <ArrowLeft size={20} className="me-1" /> 詳細へ戻る
+        </Link>
+      </div>
+
+      <header className="mb-5">
+        <h1 className="h2 fw-bold mb-2">在庫を更新する</h1>
+        <p className="text-muted">{item.name}</p>
+      </header>
+
+      <div className="row justify-content-center">
+        <div className="col-md-6">
+          <div className="card shadow-sm border-0">
+            <div className="card-body p-4">
+              <div className="mb-4 p-3 bg-light rounded">
+                <div className="d-flex justify-content-between align-items-center mb-2">
+                  <span className="text-muted small">前回更新からの経過</span>
+                  <span className="fw-bold">{daysSinceUpdate} 日</span>
+                </div>
+                <div className="d-flex justify-content-between align-items-center">
+                  <span className="text-muted small">現在の在庫（前回登録分）</span>
+                  <span className="fw-bold">{item.currentStock} {item.unit}</span>
+                </div>
+              </div>
+
+              <form onSubmit={handleSubmit}>
+                <div className="mb-4">
+                  <label className="form-label fw-bold d-flex align-items-center">
+                    <Minus size={18} className="me-2 text-warning" />
+                    消費した量 ({item.unit})
+                  </label>
+                  <div className="input-group">
+                    <button 
+                      type="button" 
+                      className="btn btn-outline-secondary"
+                      onClick={() => setConsumption(Math.max(0, consumption - 1))}
+                    >
+                      -1
+                    </button>
+                    <input 
+                      type="number" 
+                      className="form-control text-center fs-5"
+                      value={consumption}
+                      onChange={(e) => setConsumption(Math.max(0, parseFloat(e.target.value) || 0))}
+                      min="0"
+                      step="any"
+                    />
+                    <button 
+                      type="button" 
+                      className="btn btn-outline-secondary"
+                      onClick={() => setConsumption(consumption + 1)}
+                    >
+                      +1
+                    </button>
+                  </div>
+                  <div className="form-text">前回確認から今日までに消費した量を入力してください。</div>
+                </div>
+
+                <div className="mb-4">
+                  <label className="form-label fw-bold d-flex align-items-center">
+                    <Plus size={18} className="me-2 text-primary" />
+                    新しく購入した量 ({item.unit})
+                  </label>
+                  <div className="input-group">
+                    <button 
+                      type="button" 
+                      className="btn btn-outline-secondary"
+                      onClick={() => setPurchase(Math.max(0, purchase - 1))}
+                    >
+                      -1
+                    </button>
+                    <input 
+                      type="number" 
+                      className="form-control text-center fs-5"
+                      value={purchase}
+                      onChange={(e) => setPurchase(Math.max(0, parseFloat(e.target.value) || 0))}
+                      min="0"
+                      step="any"
+                    />
+                    <button 
+                      type="button" 
+                      className="btn btn-outline-secondary"
+                      onClick={() => setPurchase(purchase + 1)}
+                    >
+                      +1
+                    </button>
+                  </div>
+                  <div className="form-text">新しく補充した量がある場合に入力してください。</div>
+                </div>
+
+                <div className="mb-4">
+                  <label className="form-label fw-bold">メモ（任意）</label>
+                  <input 
+                    type="text" 
+                    className="form-control"
+                    value={memo}
+                    onChange={(e) => setMemo(e.target.value)}
+                    placeholder="例: 特売で購入"
+                  />
+                </div>
+
+                <div className="d-grid gap-2">
+                  <button 
+                    type="submit" 
+                    className="btn btn-primary btn-lg d-flex align-items-center justify-content-center"
+                    disabled={submitting || (consumption === 0 && purchase === 0)}
+                  >
+                    {submitting ? (
+                      <span className="spinner-border spinner-border-sm me-2" role="status"></span>
+                    ) : (
+                      <Save size={20} className="me-2" />
+                    )}
+                    更新を保存する
+                  </button>
+                  <Link to={`/item/${itemId}`} className="btn btn-outline-secondary">
+                    キャンセル
+                  </Link>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <div className="mt-4 p-3 bg-info bg-opacity-10 border border-info border-opacity-25 rounded">
+            <h3 className="h6 fw-bold mb-2">在庫計算の仕組み</h3>
+            <p className="small text-muted mb-0">
+              新しい在庫 = (現在の在庫) - (消費した量) + (購入した量) <br />
+              として計算されます。
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StockUpdate;


### PR DESCRIPTION
設計:
- トップページを残量予測（あと何日）を主眼とした表示に刷新
- 在庫更新機能をトップページから分離し、専用の更新画面 (StockUpdate) を新設
- 更新画面では前回登録在庫からの消費量と購入量をまとめて登録可能に

影響:
- Home.jsx: UIの大幅変更、追加・クイック更新機能の削除
- StockUpdate.jsx: 新規追加
- ItemDetail.jsx: 直接更新ボタンを削除し、更新画面へのリンクに変更
- README.md: 新しい画面構成に合わせて説明とマーメイド図を更新

テスト:
- App.test.jsx を新UIに合わせて全面的に修正し、グリーンを確認
- lint、build が正常に通ることを確認