### PR TITLE
fix(cd): CDパイプラインのタグ重複エラーを修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,11 @@ on:
     workflows: ["CI"]
     types:
       - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -38,6 +43,21 @@ jobs:
           git status -sb
           git log --oneline -5
           git tag --sort=-v:refname | head -5
+      - name: Handle tag conflict
+        run: |
+          git fetch --tags --force
+          # 最新のタグが現在のHEADの履歴に含まれていない場合、
+          # semantic-release がタグの重複エラーで失敗するのを防ぐため、
+          # fake merge (-s ours) を行い履歴を繋げる。
+          LATEST_TAG=$(git tag --sort=-v:refname | head -n 1)
+          if [ -n "$LATEST_TAG" ]; then
+            if ! git merge-base --is-ancestor "$LATEST_TAG" HEAD; then
+              echo "Warning: $LATEST_TAG is not an ancestor of HEAD. Performing a fake merge to ensure continuity."
+              git config user.name "github-actions"
+              git config user.email "github-actions@github.com"
+              git merge -s ours "$LATEST_TAG" --no-edit || echo "Merge failed, but proceeding..."
+            fi
+          fi
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
設計:
- 選定内容: GitHub ActionsのCDワークフローにおいて、最新タグを強制的にマージするステップを追加し、concurrencyを設定した。
- 却下内容: 既存タグの削除（破壊的であるため）、またはパッケージバージョンの手動更新（自動化の妨げになるため）。
- 理由: 履歴が分岐している場合にsemantic-releaseがタグの重複で失敗するのを防ぎ、かつ履歴の連続性を担保するため。

影響:
- 影響モジュール: .github/workflows/cd.yml
- 振る舞いの変更: CD実行時にタグの競合がある場合、fake mergeを行ってからリリース処理を継続する。

テスト:
- 追加済み: N/A (CI/CDワークフローの修正)
- 未追加: N/A