### PR TITLE
fix(deploy): バックエンドデプロイパイプラインの堅牢化 (v2)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -164,10 +164,7 @@ jobs:
           FORCE_DEPLOY: ${{ github.event.inputs.force_deploy || 'false' }}
       - name: 💾 Backup DynamoDB
         run: |
-          cd backend
-          # Extract JSON from serverless print output, removing any potential noise like spinners or npm notices
-          TABLE_NAMES=$(SLS_INTERACTIVE_SETUP_ENABLE=false npx serverless print --format json | node -e "const fs = require('fs'); const input = fs.readFileSync(0, 'utf8'); const match = input.match(/\{[\s\S]*\}/); if (match) console.log(JSON.stringify(JSON.parse(match[0])));" | jq -r '.resources.Resources[] | select(.Type=="AWS::DynamoDB::Table") | .Properties.TableName')
-          cd ..
+          TABLE_NAMES=$(node scripts/get-table-names.js)
           if [ -n "$TABLE_NAMES" ]; then
             node scripts/backup-dynamodb.js $TABLE_NAMES
           else

--- a/scripts/check-destructive-changes.js
+++ b/scripts/check-destructive-changes.js
@@ -9,8 +9,11 @@ function getResolvedConfig(configPath) {
     const env = { ...process.env, SLS_INTERACTIVE_SETUP_ENABLE: "false" };
     const output = execSync(cmd, { encoding: "utf8", cwd: "backend", env });
 
+    // Remove ANSI escape sequences
+    const cleanOutput = output.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
+
     // Extract JSON from output (in case of spinners or other noise)
-    const jsonMatch = output.match(/\{[\s\S]*\}/);
+    const jsonMatch = cleanOutput.match(/\{[\s\S]*\}/);
     if (!jsonMatch) {
       throw new Error("No JSON found in output");
     }

--- a/scripts/get-table-names.js
+++ b/scripts/get-table-names.js
@@ -1,0 +1,30 @@
+const { execSync } = require("child_process");
+
+function getTableNames() {
+  try {
+    const cmd = `npx serverless print --format json`;
+    const env = { ...process.env, SLS_INTERACTIVE_SETUP_ENABLE: "false" };
+    const output = execSync(cmd, { encoding: "utf8", cwd: "backend", env });
+
+    // Remove ANSI escape sequences
+    const cleanOutput = output.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
+
+    const jsonMatch = cleanOutput.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      throw new Error("No JSON found in serverless print output");
+    }
+
+    const config = JSON.parse(jsonMatch[0]);
+    const resources = config.resources?.Resources || {};
+    const tableNames = Object.values(resources)
+      .filter((res) => res.Type === "AWS::DynamoDB::Table")
+      .map((res) => res.Properties.TableName);
+
+    console.log(tableNames.join(" "));
+  } catch (error) {
+    console.error("Error getting table names:", error.message);
+    process.exit(1);
+  }
+}
+
+getTableNames();


### PR DESCRIPTION
設計:
- 選定内容: serverless print からテーブル名を取得する専用スクリプト scripts/get-table-names.js を作成。ANSIエスケープシーケンス除去ロジックを追加。
- 却下内容: YAML内での複雑なインライン Node.js スクリプト。
- 理由: 前回導入したインラインスクリプトでもノイズ（特に ANSI エスケープシーケンス）により JSON パースが失敗する場合があったため、より堅牢なスクリプトとして切り出した。

影響:
- 影響モジュール: CI/CD パイプライン、バックアップスクリプト連携
- 振る舞いの変更: デプロイパイプラインの信頼性が向上し、外部ノイズに強くなる。

テスト:
- 追加済み: scripts/get-table-names.js のローカル実行確認。
- 未追加: N/A