### PR TITLE
chore(clinerules): Serverlessのローカルチェックを必須化

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -61,6 +61,7 @@ Clineの作業を開始する前に、以下のルールを必ず遵守せよ。
 - unit test
 - test coverage (50%以上を目指し、不足している場合はテストコードを追加実装すること)
 - build（該当する場合）
+- backend deployment check（backend変更時は、リモートパイプラインの失敗を防ぐため、必ずローカルで `cd backend && npx serverless package` を実行し、デプロイ整合性を確認すること）
 
 失敗した場合は自動で修正し、再実行せよ。
 成功するまで次に進んではならない。


### PR DESCRIPTION
設計:
- 選定内容: .clinerules の「4. 静的チェック（必須）」に npx serverless package によるチェックを追加。
- 却下内容: N/A
- 理由: リモートのデプロイパイプラインで初めて失敗に気づくことを防ぎ、ローカル環境での事前検証を徹底するため。

影響:
- 影響モジュール: .clinerules
- 振る舞いの変更: バックエンド変更時に Cline が必ずパッケージングチェックを行うようになる。

テスト:
- 追加済み: N/A
- 未追加: N/A