### PR TITLE
chore(clinerules): SLSローカルチェックと安全策の追加

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -61,6 +61,7 @@ Clineの作業を開始する前に、以下のルールを必ず遵守せよ。
 - unit test
 - test coverage (50%以上を目指し、不足している場合はテストコードを追加実装すること)
 - build（該当する場合）
+- backend deployment check（backend変更時は、リモートパイプラインの失敗を防ぐため、必ずローカルで `cd backend && npx serverless package --stage local-test` を実行し、デプロイ整合性を確認すること。本番環境への影響を避けるため、必ず `local-test` 等の本番以外のステージ名を使用せよ）
 
 失敗した場合は自動で修正し、再実行せよ。
 成功するまで次に進んではならない。


### PR DESCRIPTION
設計:
- 選定内容: .clinerules に npx serverless package --stage local-test によるチェックを必須化。
- 却下内容: 本番ステージ名 (dev, prod) でのチェック。
- 理由: リモートのデプロイパイプラインでの失敗を早期に防ぎつつ、ローカルチェックが本番リソースに影響を与えないようにするため。

影響:
- 影響モジュール: .clinerules
- 振る舞いの変更: バックエンド変更時、Cline が local-test ステージを指定してパッケージングチェックを必ず行うようになる。

テスト:
- 追加済み: N/A
- 未追加: N/A