### PR TITLE
fix(ci): mergeジョブにおけるマージ可能性の判定と待機処理の追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,29 @@ jobs:
             try {
               // ベースブランチが更新されている場合に備えて最新化を試みる
               try {
-                await github.rest.pulls.updateBranch({
+                const { data: pullRequest } = await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: prNumber,
                 });
-                console.log(`Updated branch for PR #${prNumber}`);
+
+                if (pullRequest.mergeable_state === 'behind') {
+                  console.log(`PR #${prNumber} is behind base branch. Updating...`);
+                  await github.rest.pulls.updateBranch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber,
+                  });
+                  console.log(`Updated branch for PR #${prNumber}`);
+                } else {
+                  console.log(`PR #${prNumber} mergeable state: ${pullRequest.mergeable_state}`);
+                }
               } catch (updateError) {
-                console.log(`Note: Could not update branch (maybe already up to date): ${updateError.message}`);
+                console.log(`Note: Could not update branch: ${updateError.message}`);
               }
+
+              // マージ可能になるまで少し待機 (GitHub APIの反映待ち)
+              await new Promise(resolve => setTimeout(resolve, 5000));
 
               await github.rest.pulls.merge({
                 owner: context.repo.owner,
@@ -139,4 +153,3 @@ jobs:
                 console.error(`Failed to delete branch ${branchName}:`, error.message);
               }
             }
-            


### PR DESCRIPTION
設計:
- 選定内容: マージ前にgithub.rest.pulls.getでmergeable_stateを確認し、'behind'の場合はupdateBranchを実行。また、GitHub APIの反映待ちとして5秒のディレイを追加。
- 却下内容: 即座にmergeをリトライし続けるループ処理。
- 理由: ループ処理はAPIレートリミットに達するリスクがあるため、最小限の待機と事前チェックを優先。

影響:
- 影響モジュール: CIパイプライン (GitHub Actions)
- 振る舞いの変更: PRがベースブランチより古い場合に自動更新を試み、ステータスチェックの反映を待ってからマージを実行するように変更。

テスト:
- 追加済み: N/A (CI設定の変更)
- 未追加: N/A