### PR TITLE
fix(db): StockHistoryTableの名前をv3に更新

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -26,7 +26,7 @@ provider:
 custom:
   appName: uchi-stock-app
   tableName: ${self:custom.appName}-items-v2
-  stockHistoryTableName: ${self:custom.appName}-stock-history-v2
+  stockHistoryTableName: ${self:custom.appName}-stock-history-v3
   cognitoUserPoolArn: ${env:COGNITO_USER_POOL_ARN, 'arn:aws:cognito-idp:ap-northeast-1:123456789012:userpool/ap-northeast-1_example'}
 
 functions:


### PR DESCRIPTION
設計:
- 選定内容: StockHistoryTable のテーブル名を v2 から v3 に変更。
- 却下内容: 既存テーブルの GSI を段階的に変更（CI環境での制御が困難なため）。
- 理由: DynamoDB の制限（1回の更新で複数のGSI操作不可）によりデプロイが失敗していた。テーブル名を変更して新規作成扱いとすることで、この制限を回避し、構造変更を一括で反映させる。

影響:
- 影響モジュール: backend/serverless.yml
- 振る舞いの変更: 履歴データ保存先が v3 テーブルに変更される。既存の v2 データは自動的には引き継がれない。

テスト:
- 追加済み: npx serverless package --stage local-test による整合性チェック。
- 未追加: N/A