### PR TITLE
chore(deploy): Serverlessのログ出力を抑制

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -142,6 +142,9 @@ jobs:
   deploy-backend:
     needs: release
     runs-on: ubuntu-latest
+    env:
+      SLS_INTERACTIVE_SETUP_ENABLE: false
+      CI: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -165,7 +168,7 @@ jobs:
       - name: 💾 Backup DynamoDB
         run: |
           # Extract table names using a robust inline script that handles ANSI noise and JSON parsing
-          TABLE_NAMES=$(cd backend && SLS_INTERACTIVE_SETUP_ENABLE=false npx serverless print --format json | node -e "const input = require('fs').readFileSync(0, 'utf8').replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''); const match = input.match(/\{[\s\S]*\}/); if (match) { const config = JSON.parse(match[0]); const resources = config.resources?.Resources || {}; const tableNames = Object.values(resources).filter(res => res.Type === 'AWS::DynamoDB::Table').map(res => res.Properties.TableName); console.log(tableNames.join(' ')); }")
+          TABLE_NAMES=$(cd backend && npx serverless print --format json | node -e "const input = require('fs').readFileSync(0, 'utf8').replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''); const match = input.match(/\{[\s\S]*\}/); if (match) { const config = JSON.parse(match[0]); const resources = config.resources?.Resources || {}; const tableNames = Object.values(resources).filter(res => res.Type === 'AWS::DynamoDB::Table').map(res => res.Properties.TableName); console.log(tableNames.join(' ')); }")
           if [ -n "$TABLE_NAMES" ]; then
             node scripts/backup-dynamodb.js $TABLE_NAMES
           else
@@ -181,7 +184,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SLS_INTERACTIVE_SETUP_ENABLE: false
       - name: 🌱 Seed Database
         working-directory: backend
         run: node seed.js


### PR DESCRIPTION
設計:
- 選定内容: cd.yml の deploy-backend ジョブに CI: true および SLS_INTERACTIVE_SETUP_ENABLE: false 環境変数を追加。
- 却下内容: N/A
- 理由: パイプラインのログに大量のスピナー（進捗状況）が出力され、視認性が低下していたため、CI環境向けの抑制設定を適用した。

影響:
- 影響モジュール: CI/CD パイプライン
- 振る舞いの変更: GitHub Actions のログがクリーンになり、デプロイ結果を確認しやすくなる。

テスト:
- 追加済み: N/A
- 未追加: 実際の CI 環境でのログ出力確認。