### PR TITLE
fix(deploy): ジョブ分離、GSI制限回避、ログ抑制の強化

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -145,6 +145,8 @@ jobs:
     env:
       SLS_INTERACTIVE_SETUP_ENABLE: false
       CI: true
+      SLS_TTY: false
+      TERM: dumb
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -168,7 +170,8 @@ jobs:
       - name: 💾 Backup DynamoDB
         run: |
           # Extract table names using a robust inline script that handles ANSI noise and JSON parsing
-          TABLE_NAMES=$(cd backend && npx serverless print --format json | node -e "const input = require('fs').readFileSync(0, 'utf8').replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''); const match = input.match(/\{[\s\S]*\}/); if (match) { const config = JSON.parse(match[0]); const resources = config.resources?.Resources || {}; const tableNames = Object.values(resources).filter(res => res.Type === 'AWS::DynamoDB::Table').map(res => res.Properties.TableName); console.log(tableNames.join(' ')); }")
+          # Pipe to cat to suppress TTY/spinner features
+          TABLE_NAMES=$(cd backend && npx serverless print --format json | cat | node -e "const input = require('fs').readFileSync(0, 'utf8').replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''); const match = input.match(/\{[\s\S]*\}/); if (match) { const config = JSON.parse(match[0]); const resources = config.resources?.Resources || {}; const tableNames = Object.values(resources).filter(res => res.Type === 'AWS::DynamoDB::Table').map(res => res.Properties.TableName); console.log(tableNames.join(' ')); }")
           if [ -n "$TABLE_NAMES" ]; then
             node scripts/backup-dynamodb.js $TABLE_NAMES
           else
@@ -180,10 +183,28 @@ jobs:
           AWS_REGION: ap-northeast-1
       - name: 🚀 Deploy Backend (Serverless Framework)
         working-directory: backend
-        run: npx serverless deploy
+        run: npx serverless deploy | cat
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  seed-backend:
+    needs: deploy-backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install Backend dependencies
+        working-directory: backend
+        run: npm ci
       - name: 🌱 Seed Database
         working-directory: backend
         run: node seed.js

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -21,7 +21,7 @@ provider:
             - dynamodb:DeleteItem
           Resource:
             - !GetAtt HouseholdItemsTable.Arn
-            - !GetAtt StockHistoryTable.Arn
+            - !GetAtt StockHistoryTableV3.Arn
 
 custom:
   appName: uchi-stock-app
@@ -178,7 +178,7 @@ resources:
         BillingMode: PAY_PER_REQUEST
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: true
-    StockHistoryTable:
+    StockHistoryTableV3:
       Type: AWS::DynamoDB::Table
       Properties:
         TableName: ${self:custom.stockHistoryTableName}


### PR DESCRIPTION
設計:
- 選定内容:
  1. cd.yml にてデプロイとシード投入を別ジョブ (deploy-backend, seed-backend) に分離。
  2. serverless.yml の StockHistoryTable 論理IDを StockHistoryTableV3 に変更。
  3. SLS_TTY=false, TERM=dumb, | cat パイプによるログ抑制を導入。
- 却下内容: N/A
- 理由:
  - データ投入時のエラーがデプロイ成否と混同されないようにするため。
  - 1回の更新で複数の GSI 操作を禁止する DynamoDB の制限を、論理ID変更による新規作成扱いで回避するため。
  - CIログの視認性を極限まで高めるため。

影響:
- 影響モジュール: CI/CD パイプライン, backend/serverless.yml
- 振る舞いの変更:
  - デプロイ後にシード投入が別ジョブとして走る。
  - StockHistoryTable が置換（再作成）される。

テスト:
- 追加済み: npx serverless package --stage local-test による整合性確認。
- 未追加: N/A