### PR TITLE
fix(deploy): パイプラインの失敗検知修正とGSI制限回避のためのV4移行

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -183,7 +183,7 @@ jobs:
           AWS_REGION: ap-northeast-1
       - name: 🚀 Deploy Backend (Serverless Framework)
         working-directory: backend
-        run: npx serverless deploy | cat
+        run: npx serverless deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -21,12 +21,12 @@ provider:
             - dynamodb:DeleteItem
           Resource:
             - !GetAtt HouseholdItemsTable.Arn
-            - !GetAtt StockHistoryTableV3.Arn
+            - !GetAtt StockHistoryTableV4.Arn
 
 custom:
   appName: uchi-stock-app
   tableName: ${self:custom.appName}-items-v2
-  stockHistoryTableName: ${self:custom.appName}-stock-history-v3
+  stockHistoryTableName: ${self:custom.appName}-stock-history-v4
   cognitoUserPoolArn: ${env:COGNITO_USER_POOL_ARN, 'arn:aws:cognito-idp:ap-northeast-1:123456789012:userpool/ap-northeast-1_example'}
 
 functions:
@@ -178,7 +178,7 @@ resources:
         BillingMode: PAY_PER_REQUEST
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: true
-    StockHistoryTableV3:
+    StockHistoryTableV4:
       Type: AWS::DynamoDB::Table
       Properties:
         TableName: ${self:custom.stockHistoryTableName}


### PR DESCRIPTION
設計:
- 選定内容:
  1. .github/workflows/cd.yml のデプロイステップから `| cat` を削除。
  2. backend/serverless.yml の StockHistoryTable を V4 (論理ID/物理名共) に更新。
- 却下内容: 既存の V3 のままデプロイを再試行すること。
- 理由:
  - パイプラインでの `| cat` 使用は終了コードを隠蔽し、デプロイ失敗を正常終了と誤認させる原因となるため。
  - DynamoDBのGSI制限によるエラーが解消されない可能性があるため、論理IDと物理名を刷新して新規作成を強制し、既存の不整合を回避する。

影響:
- 影響モジュール: CDパイプライン, backend/serverless.yml
- 振る舞いの変更: デプロイ失敗時にパイプラインが正しく停止するようになる。StockHistoryTable が V4 として新規作成される。

テスト:
- 追加済み: backend/handler.test.js (既存), npx serverless package による整合性確認
- 未追加: N/A