### PR TITLE
fix(deploy): changelogジョブのみreleaseブランチを対象にするよう修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,9 +68,10 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout release branch
         uses: actions/checkout@v4
         with:
+          ref: release
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
設計:
- 選定内容: .github/workflows/cd.yml の changelog ジョブに ref: release を再設定。
- 却下内容: 全てのジョブで main を使用すること。
- 理由: デプロイ自体は main ブランチのコードで行いたいが、CHANGELOG などの成果物のプッシュ先は release ブランチに限定したいため（mainへの直接プッシュ禁止ルールを考慮）。

影響:
- 影響モジュール: CDパイプライン
- 振る舞いの変更: changelog ジョブが正しく release ブランチをチェックアウト・更新・プッシュできるようになる。

テスト:
- 追加済み: N/A
- 未追加: N/A