### PR TITLE
fix(ci): CDワークフローがCI成功時のみ実行されるように修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success'
     name: Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
設計:
- 選定内容: workflow_run の conclusion チェックを追加
- 却下内容: 依存関係を needs で制御（別ファイルのため不可）
- 理由: workflow_run トリガーの場合、前続ワークフローの成否を明示的にチェックする必要があるため

影響:
- 影響モジュール: GitHub Actions (CD)
- 振る舞いの変更: CIが失敗した場合、CDのジョブがスキップされるようになる

テスト:
- 追加済み: N/A (GitHub Actionsの設定変更のためローカルテスト不可)
- 未追加: N/A