### PR TITLE
fix(seed): シードスクリプトの履歴テーブル名をv4に更新

### DIFF
--- a/backend/seed-test-stock-prediction.js
+++ b/backend/seed-test-stock-prediction.js
@@ -6,7 +6,7 @@ const client = new DynamoDBClient({ region: "ap-northeast-1" });
 const docClient = DynamoDBDocumentClient.from(client);
 
 const ITEMS_TABLE = "uchi-stock-app-items-v2";
-const HISTORY_TABLE = "uchi-stock-app-stock-history-v2";
+const HISTORY_TABLE = "uchi-stock-app-stock-history-v4";
 const DEFAULT_USER_ID = "test-user";
 
 // テストケース定義（docs/test-strategy-stock-prediction.md に基づく）


### PR DESCRIPTION
設計:
- 選定内容: HISTORY_TABLE を uchi-stock-app-stock-history-v4 に変更
- 却下内容: N/A
- 理由: serverless.yml で定義されている最新のテーブル名と不一致であり、ResourceNotFoundException が発生していたため

影響:
- 影響モジュール: backend (seed script)
- 振る舞いの変更: テスト用シードデータが正しいテーブルに投入されるようになる

テスト:
- 追加済み: N/A (既存テストのパスを確認)
- 未追加: N/A