### PR TITLE
refactor: ItemsテーブルのupdatedAtカラムを削除

### DIFF
--- a/backend/seed-stock.js
+++ b/backend/seed-stock.js
@@ -163,7 +163,6 @@ async function seed(dryRun = false) {
             unit: itemDef.unit,
             currentStock: Math.max(0, calculatedStock),
             createdAt,
-            updatedAt: now.toISOString(),
           },
         }));
       }

--- a/backend/seed-test-stock-prediction.js
+++ b/backend/seed-test-stock-prediction.js
@@ -202,7 +202,6 @@ async function seedTestData(dryRun = false) {
             unit: testCase.unit,
             currentStock: Math.max(0, calculatedStock),
             createdAt,
-            updatedAt: now.toISOString(),
           },
         }));
       }


### PR DESCRIPTION
設計:
- 選定内容: ItemsテーブルのupdatedAtカラムを削除し、getItems API等で履歴テーブルから最新のタイムスタンプを動的に取得するよう変更。
- 却下内容: 既存のupdatedAtカラムを維持し続けること（データの冗長性を排除するため）。
- 理由: 履歴データが真の更新情報を保持しているため、カラムを分ける必要がない。

影響:
- 影響モジュール: backend/handler.js, backend/seed-stock.js, backend/seed-test-stock-prediction.js
- 振る舞いの変更: ItemsテーブルにupdatedAtが保存されなくなる。APIレスポンスには引き続きupdatedAtが含まれる（履歴から算出）。品目作成・更新時に履歴レコード（creation, update）が作成されるようになる。

テスト:
- 追加済み: backend/handler.test.js に履歴からupdatedAtを取得するテスト、およびフォールバックのテストを追加。
- 未追加: N/A