### PR TITLE
feat(stock): 在庫予測を割合表示に変更

### DIFF
--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -366,6 +366,10 @@ describe('Household Items API', () => {
           averageConsumptionRate: 2.0 // 1日2個消費
         }
       });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
+      });
 
       const result = await getEstimatedDepletionDate({
         headers: { 'x-user-id': TEST_USER },
@@ -392,6 +396,10 @@ describe('Household Items API', () => {
           averageConsumptionRate: 2.0 // 1日2個消費
         }
       });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
+      });
 
       const result = await getEstimatedDepletionDate({
         headers: { 'x-user-id': TEST_USER },
@@ -406,6 +414,8 @@ describe('Household Items API', () => {
       expect(body.estimatedDepletionDate).toBe('2023-01-10T12:00:00.000Z');
       expect(body.dailyConsumption).toBe("2.00");
       expect(body.currentStock).toBe(10);
+      expect(body.stockPercentage).toBe(50); // 10/20 = 50%
+      expect(body.lastPurchaseQuantity).toBe(20);
     });
 
     it('should use current date when invalid date parameter is provided', async () => {
@@ -416,6 +426,10 @@ describe('Household Items API', () => {
           currentStock: 10,
           averageConsumptionRate: 2.0 // 1日2個消費
         }
+      });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -505,6 +519,10 @@ describe('Household Items API', () => {
           averageConsumptionRate: 1.0
         }
       });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
+      });
 
       const result = await getEstimatedDepletionDate({
         headers: { 'x-user-id': TEST_USER },
@@ -529,6 +547,10 @@ describe('Household Items API', () => {
           averageConsumptionRate: 1.0
         }
       });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
+      });
 
       const result = await getEstimatedDepletionDate({
         headers: { 'x-user-id': TEST_USER },
@@ -551,6 +573,10 @@ describe('Household Items API', () => {
           averageConsumptionRate: 1.0 // 変動平均
         }
       });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
+      });
 
       const result = await getEstimatedDepletionDate({
         headers: { 'x-user-id': TEST_USER },
@@ -572,6 +598,10 @@ describe('Household Items API', () => {
           currentStock: 15,
           averageConsumptionRate: 1.0
         }
+      });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -640,6 +670,10 @@ describe('Household Items API', () => {
           currentStock: 10,
           averageConsumptionRate: 0.1 // 古いデータによる低い消費率
         }
+      });
+      // 購入履歴のモック
+      ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
+        Items: [{ quantity: 20, type: 'purchase' }]
       });
 
       const result = await getEstimatedDepletionDate({

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -122,19 +122,22 @@ function Home() {
                   ? Math.ceil((new Date(item.estimate.estimatedDepletionDate) - selectedDate) / (1000 * 60 * 60 * 24))
                   : null;
                 
-                let statusClass = "bg-success";
-                let statusText = "余裕あり";
-                if (daysRemaining !== null) {
-                  if (daysRemaining <= 3) {
+                let statusClass = "bg-secondary";
+                let statusText = "在庫割合不明";
+                const stockPercentage = item.estimate?.stockPercentage;
+
+                if (stockPercentage !== undefined && stockPercentage !== null) {
+                  statusText = `在庫残り ${stockPercentage}%`;
+                  if (stockPercentage <= 20) {
                     statusClass = "bg-danger";
-                    statusText = "まもなく在庫切れ";
-                  } else if (daysRemaining <= 7) {
+                  } else if (stockPercentage <= 50) {
                     statusClass = "bg-warning text-dark";
-                    statusText = "少なくなっています";
+                  } else {
+                    statusClass = "bg-success";
                   }
                 } else if (item.currentStock === 0) {
-                    statusClass = "bg-danger";
-                    statusText = "在庫なし";
+                  statusClass = "bg-danger";
+                  statusText = "在庫なし";
                 }
 
                 return (


### PR DESCRIPTION
設計:
- 選定内容: 在庫切れ予想エンドポイントで最後に購入した数量を取得し、現在の在庫との割合を算出するように変更。
- 却下内容: アイテムテーブルに最大在庫数を持たせる案。
- 理由: 最後に購入した数量を「満タン」と見なす方が、ユーザーの手動設定なしに直感的な割合を出せると判断。

影響:
- 影響モジュール: backend/handler.js, frontend/src/components/Home.jsx
- 振る舞いの変更: 在庫ステータスが「余裕あり」「在庫なし」から「在庫残り X%」に変更。

テスト:
- 追加済み: backend/handler.test.js に在庫割合計算のテストを追加。
- 未追加: N/A