### PR TITLE
feat(stock): 在庫予想ロジックの修正

### DIFF
--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -368,7 +368,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -398,7 +400,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -429,7 +433,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -521,7 +527,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -549,7 +557,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -575,7 +585,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -601,7 +613,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({
@@ -673,7 +687,9 @@ describe('Household Items API', () => {
       });
       // 購入履歴のモック
       ddbMock.on(QueryCommand, { TableName: HISTORY_TABLE }).resolves({
-        Items: [{ quantity: 20, type: 'purchase' }]
+        Items: [
+          { quantity: 20, type: 'purchase', date: '2023-01-01T12:00:00Z' }
+        ]
       });
 
       const result = await getEstimatedDepletionDate({


### PR DESCRIPTION
設計:
- 選定内容: 最後に在庫数を更新した日時を基準に、現在までの経過日数と現在の在庫数から計算される残り日数を合算して在庫切れ予想日を算出するロジックに変更。
- 却下内容: 現在日時から単純に (在庫数 / 平均消費ペース) を足す方式を廃止（過去に入力が途切れていた場合に未来にずれすぎるため）。
- 理由: 最後に確認された「正しい在庫数」から、平均ペースで減っていった場合にいつゼロになるか、という物理的な予測に合わせるため。

影響:
- 影響モジュール: backend/handler.js (getEstimatedDepletionDate)
- 振る舞いの変更: 在庫切れ予想日がより正確になり、長期間入力がない場合でも過去の更新時点からの消費を考慮した日付が返るようになる。

テスト:
- 追加済み: handler.test.js における各ケース（単純消費、低在庫、補充後など）の期待値確認-
- 未追加: N/A