### PR TITLE
feat(frontend): 履歴詳細に残量列を追加

### DIFF
--- a/frontend/src/components/ItemDetail.test.jsx
+++ b/frontend/src/components/ItemDetail.test.jsx
@@ -124,6 +124,13 @@ describe('ItemDetail', () => {
       expect(screen.getByText('購入')).toBeInTheDocument();
       expect(screen.getByText('Used')).toBeInTheDocument();
       expect(screen.getByText('Bought')).toBeInTheDocument();
+      // 残量の表示確認
+      // mockHistoryは降順で届く想定。
+      // 現在の在庫 10
+      // 1件目 (h1): consumption 2 -> 直前の在庫は 10.
+      // 2件目 (h2): purchase 5 -> 直前の在庫は 10 + 2 = 12. 直前の在庫は 12.
+      expect(screen.getByText('10 pcs')).toBeInTheDocument();
+      expect(screen.getByText('12 pcs')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
設計:
- 選定内容: 履歴詳細テーブルに「残量」列を追加し、各アクション実行後の在庫数を表示するよう実装。
- 却下内容: バックエンドでの計算・返却。
- 理由: 既存の在庫履歴取得APIのレスポンスを変更せず、フロントエンド側で現在の在庫数から逆算することで、最小限の変更で要件を満たせると判断したため。

影響:
- 影響モジュール: ItemDetail.jsx
- 振る舞いの変更: 履歴詳細テーブルに「残量」列が表示されるようになった。

テスト:
- 追加済み: ItemDetail.test.jsx にて残量の表示ロジックを確認するテストを追加。
- 未追加: N/A