### PR TITLE
feat(stock): 予測在庫を表示するように変更

### DIFF
--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -284,7 +284,9 @@ function Home() {
                         
                         <div className="mb-4">
                           <div className="d-flex align-items-center gap-2 mb-3">
-                            <span className="display-6 fw-bold">{item.currentStock}</span>
+                            <span className="display-6 fw-bold">
+                              {item.estimate?.predictedStock !== undefined ? item.estimate.predictedStock : item.currentStock}
+                            </span>
                             <span className="text-muted">{item.unit}</span>
                           </div>
 

--- a/frontend/src/components/Home.test.jsx
+++ b/frontend/src/components/Home.test.jsx
@@ -44,7 +44,7 @@ describe("Home Component", () => {
       if (url.includes("/estimate")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ stockPercentage: 50 }),
+          json: () => Promise.resolve({ predictedStock: 5, stockPercentage: 50 }),
         });
       }
       return Promise.resolve({
@@ -105,5 +105,28 @@ describe("Home Component", () => {
 
     // Form should be closed
     expect(screen.queryByText("新しい品目の登録")).not.toBeInTheDocument();
+  });
+
+  it("displays predicted stock when available", async () => {
+    fetch.mockImplementation((url) => {
+      if (url.includes("/estimate")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ predictedStock: 3, stockPercentage: 60 }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockItems),
+      });
+    });
+
+    renderHome();
+    await waitFor(() => {
+      // predictedStock の 3 が表示されていることを確認
+      expect(screen.getByText("3")).toBeInTheDocument();
+      // currentStock の 5 ではないことを確認
+      expect(screen.queryByText("5")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/ItemDetail.jsx
+++ b/frontend/src/components/ItemDetail.jsx
@@ -99,7 +99,7 @@ const ItemDetail = () => {
     const trend = [
       {
         date: "現在",
-        stock: item.currentStock,
+        stock: estimate?.predictedStock !== undefined ? estimate.predictedStock : item.currentStock,
         displayDate: new Date().toLocaleDateString(),
       },
     ];
@@ -113,7 +113,7 @@ const ItemDetail = () => {
     });
 
     return trend.reverse();
-  }, [item, historyWithStockLevel]);
+  }, [item, historyWithStockLevel, estimate]);
 
   if (loading) {
     return (
@@ -149,7 +149,9 @@ const ItemDetail = () => {
           <div className="col-md-6">
             <h1 className="display-5 fw-bold mb-2">{item.name}</h1>
             <div className="d-flex align-items-baseline">
-              <span className="display-6 me-2">{item.currentStock}</span>
+              <span className="display-6 me-2">
+                {estimate?.predictedStock !== undefined ? estimate.predictedStock : item.currentStock}
+              </span>
               <span className="text-muted fs-4">{item.unit}</span>
             </div>
           </div>

--- a/frontend/src/components/ItemDetail.test.jsx
+++ b/frontend/src/components/ItemDetail.test.jsx
@@ -47,6 +47,7 @@ const mockHistory = [
 const mockEstimate = {
   estimatedDepletionDate: '2023-01-10T12:00:00Z',
   dailyConsumption: '0.5',
+  predictedStock: 8.5,
 };
 
 describe('ItemDetail', () => {
@@ -87,7 +88,7 @@ describe('ItemDetail', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Test Item')).toBeInTheDocument();
-      expect(screen.getByText('10')).toBeInTheDocument();
+      expect(screen.getByText('8.5')).toBeInTheDocument();
       expect(screen.getByText('pcs')).toBeInTheDocument();
       expect(screen.getByText('0.5 pcs / 日')).toBeInTheDocument();
     });


### PR DESCRIPTION
設計:
- 選定内容: バックエンドの estimate API で predictedStock を計算し、フロントエンドでそれを優先的に表示するようにした。
- 却下内容: フロントエンド側での計算。
- 理由: 基準日や平均消費ペースのロジックがバックエンドに集約されているため、バックエンドで計算する方が正確で保守性が高いため。

影響:
- 影響モジュール: backend/handler.js, frontend/src/components/Home.jsx, frontend/src/components/ItemDetail.jsx
- 振る舞いの変更: 在庫一覧および詳細画面で、最終更新時の在庫ではなく、基準日（または現在）における予測在庫が表示されるようになる。

テスト:
- 追加済み: backend/handler.test.js, frontend/src/components/Home.test.jsx, frontend/src/components/ItemDetail.test.jsx
- 未追加: N/A