### PR TITLE
test(prediction): fix timing of mid-term replenishment in test data

### DIFF
--- a/backend/seed-test-stock-prediction.js
+++ b/backend/seed-test-stock-prediction.js
@@ -60,9 +60,11 @@ const testCases = [
     unit: "個",
     expectedDays: 18, // 補充後から再計算
     history: [
-      { daysAgo: 15, type: "purchase", quantity: 5, memo: "初期購入" },
+      { daysAgo: 15, type: "purchase", quantity: 8, memo: "初期購入" },
+      { daysAgo: 15, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 14, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 13, type: "consumption", quantity: 1, memo: "消費" },
+      { daysAgo: 12, type: "purchase", quantity: 10, memo: "途中補充" }, // 初期購入から3日後
       { daysAgo: 12, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 11, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 10, type: "consumption", quantity: 1, memo: "消費" },
@@ -71,7 +73,8 @@ const testCases = [
       { daysAgo: 7, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 6, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 5, type: "consumption", quantity: 1, memo: "消費" },
-      { daysAgo: 3, type: "purchase", quantity: 10, memo: "途中補充" }, // 3日後補充
+      { daysAgo: 4, type: "consumption", quantity: 1, memo: "消費" },
+      { daysAgo: 3, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 2, type: "consumption", quantity: 1, memo: "消費" },
       { daysAgo: 1, type: "consumption", quantity: 1, memo: "消費" }
     ]


### PR DESCRIPTION
設計:
- 選定内容: 途中補充ケースの補充タイミングを初期購入から3日後（12日前）に修正。
- 却下内容: 期待値の変更。履歴データの調整により既存の期待値(18日後)と整合させた。
- 理由: ユーザーの指摘通り、補充タイミングが初期購入から12日後になっていたため。

影響:
- 影響モジュール: backend/seed-test-stock-prediction.js
- 振る舞いの変更: テストデータ生成時の補充レコードの日付が修正される。

テスト:
- 追加済み: backend/seed-test-stock-prediction.js の修正後の dry-run による計算在庫の確認。
- 未追加: N/A