### PR TITLE
feat(cd): CDワークフローにFIREBASE_SERVICE_ACCOUNT環境変数を追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -192,6 +192,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
   seed-backend:
     needs: deploy-backend
@@ -216,6 +217,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
       - name: 🧪 Seed Test Data for Stock Prediction
         if: ${{ inputs.force_seed == true || github.event.inputs.force_seed == 'true' }}
         working-directory: backend
@@ -223,3 +225,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}


### PR DESCRIPTION
設計:
- 選定内容: .github/workflows/cd.yml の deploy-backend および seed-backend ジョブに FIREBASE_SERVICE_ACCOUNT 環境変数を追加。
- 却下内容: serverless.yml 側での固定値定義（セキュリティ上の理由）。
- 理由: バックエンドの認証トークン検証に Firebase Admin SDK を使用しており、その初期化にこの環境変数が必要であるため。

影響:
- 影響モジュール: .github/workflows/cd.yml
- 振る舞いの変更: デプロイ時およびシードデータ投入時に FIREBASE_SERVICE_ACCOUNT が正しくバックエンド環境に渡されるようになる。

テスト:
- 追加済み: N/A (ワークフロー定義の修正)
- 未追加: N/A