### PR TITLE
feat(auth): ユーザー管理テーブルの導入とプロフィール同期の実装

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -9,6 +9,7 @@ provider:
   environment:
     TABLE_NAME: ${self:custom.tableName}
     STOCK_HISTORY_TABLE_NAME: ${self:custom.stockHistoryTableName}
+    USERS_TABLE_NAME: ${self:custom.usersTableName}
     FIREBASE_SERVICE_ACCOUNT: ${env:FIREBASE_SERVICE_ACCOUNT, ''}
     ALLOW_INSECURE_USER_ID: ${env:ALLOW_INSECURE_USER_ID, 'false'}
   iam:
@@ -25,11 +26,13 @@ provider:
           Resource:
             - !GetAtt HouseholdItemsTable.Arn
             - !GetAtt StockHistoryTableV4.Arn
+            - !GetAtt UsersTable.Arn
 
 custom:
   appName: uchi-stock-app
   tableName: ${self:custom.appName}-items-v2
   stockHistoryTableName: ${self:custom.appName}-stock-history-v4
+  usersTableName: ${self:custom.appName}-users-v1
 
 functions:
   createItem:
@@ -177,6 +180,28 @@ resources:
             KeyType: HASH
           - AttributeName: itemId
             KeyType: RANGE
+        BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+    UsersTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.usersTableName}
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: email
+            AttributeType: S
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: EmailIndex
+            KeySchema:
+              - AttributeName: email
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
         BillingMode: PAY_PER_REQUEST
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: true

--- a/docs/internal-design.md
+++ b/docs/internal-design.md
@@ -17,7 +17,7 @@
 ### ユーザー特定ロジック
 バックエンド（`handler.js`）では、以下の優先順位でユーザーID（`userId`）を特定します。
 
-1.  **Firebase ID Token**: `Authorization: Bearer <token>` ヘッダーから取得。`firebase-admin` SDKを使用してトークンを検証し、UIDを取得します。
+1.  **Firebase ID Token**: `Authorization: Bearer <token>` ヘッダーから取得。`firebase-admin` SDKを使用してトークンを検証し、UIDを取得します。また、この時に取得されるメールアドレスや表示名などのプロフィール情報は、`users` テーブルに自動的に同期されます。
 2.  **テストモード**: `x-user-id: test-user` が指定されている場合、認証なしでアクセスを許可します。これはログイン未済のユーザーが試用するための仕様です。
 3.  **開発用 fallback**: `x-user-id` ヘッダー。開発およびローカルテスト環境での利便性のために維持（`ALLOW_INSECURE_USER_ID=true` または `NODE_ENV=test` の場合のみ有効）。
 
@@ -149,3 +149,14 @@ graph TD
 | type | String | - | 履歴の種類（"purchase", "consumption"） |
 | quantity | Number | - | 数量 |
 | memo | String | - | メモ (任意) |
+
+### 3. users
+ユーザーのプロフィール情報を管理するテーブル。デバッグのしやすさの向上および将来の共有機能（お友達登録）のために使用されます。
+
+| 属性名 | 型 | キー | 説明 |
+| :--- | :--- | :--- | :--- |
+| userId | String | Partition Key | ログインユーザーID (Firebase UID) |
+| email | String | GSI (EmailIndex) | メールアドレス |
+| displayName | String | - | 表示名 |
+| photoURL | String | - | プロフィール画像URL |
+| updatedAt | String | - | 最終同期日時 (ISO8601) |


### PR DESCRIPTION
設計:
- 選定内容: Firebase UIDをキーとし、email/displayNameを保持するusersテーブルを新設。EmailIndex(GSI)を追加。
- 却下内容: アイテムテーブルのパーティションキーをメールアドレスに変更する案（変更耐性が低いため却下）。
- 理由: デバッグのしやすさを向上させつつ、将来の家族共有機能（メールアドレス検索）の土台を構築するため。

影響:
- 影響モジュール: backend/serverless.yml, backend/handler.js, docs/internal-design.md
- 振る舞いの変更: APIリクエスト時にFirebaseから得られたプロフィール情報が自動的にDynamoDBへ同期される。

テスト:
- 追加済み: backend/handler.test.js にユーザー同期のユニットテストを追加。
- 未追加: N/A