### PR TITLE
feat(sharing): 家族登録機能の実装

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -10,6 +10,8 @@ provider:
     TABLE_NAME: ${self:custom.tableName}
     STOCK_HISTORY_TABLE_NAME: ${self:custom.stockHistoryTableName}
     USERS_TABLE_NAME: ${self:custom.usersTableName}
+    FAMILIES_TABLE_NAME: ${self:custom.familiesTableName}
+    INVITATIONS_TABLE_NAME: ${self:custom.invitationsTableName}
     FIREBASE_SERVICE_ACCOUNT: ${env:FIREBASE_SERVICE_ACCOUNT, ''}
     ALLOW_INSECURE_USER_ID: ${env:ALLOW_INSECURE_USER_ID, 'false'}
   iam:
@@ -27,12 +29,16 @@ provider:
             - !GetAtt HouseholdItemsTable.Arn
             - !GetAtt StockHistoryTableV4.Arn
             - !GetAtt UsersTable.Arn
+            - !GetAtt FamiliesTable.Arn
+            - !GetAtt InvitationsTable.Arn
 
 custom:
   appName: uchi-stock-app
   tableName: ${self:custom.appName}-items-v2
   stockHistoryTableName: ${self:custom.appName}-stock-history-v4
   usersTableName: ${self:custom.appName}-users-v1
+  familiesTableName: ${self:custom.appName}-families-v1
+  invitationsTableName: ${self:custom.appName}-invitations-v1
 
 functions:
   createItem:
@@ -163,6 +169,54 @@ functions:
               - X-Amz-Security-Token
               - X-Amz-User-Agent
               - x-user-id
+  createInvitation:
+    handler: handler.createInvitation
+    events:
+      - http:
+          path: invitations
+          method: post
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
+  acceptInvitation:
+    handler: handler.acceptInvitation
+    events:
+      - http:
+          path: invitations/accept
+          method: post
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
+  getFamilies:
+    handler: handler.getFamilies
+    events:
+      - http:
+          path: families
+          method: get
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-user-id
 
 resources:
   Resources:
@@ -203,6 +257,39 @@ resources:
             Projection:
               ProjectionType: ALL
         BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+    FamiliesTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.familiesTableName}
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: familyUserId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+          - AttributeName: familyUserId
+            KeyType: RANGE
+        BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+    InvitationsTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.invitationsTableName}
+        AttributeDefinitions:
+          - AttributeName: invitationToken
+            AttributeType: S
+        KeySchema:
+          - AttributeName: invitationToken
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        TimeToLiveSpecification:
+          AttributeName: expiresAt
+          Enabled: true
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: true
     StockHistoryTableV4:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import Home from "./components/Home";
 import ItemDetail from "./components/ItemDetail";
 import StockUpdate from "./components/StockUpdate";
+import FamilyInvite from "./components/FamilyInvite";
+import InviteAccept from "./components/InviteAccept";
 import { UserProvider } from "./contexts/UserProvider";
 import { useUser } from "./contexts/UserContext";
 import "./App.css";
@@ -25,6 +27,8 @@ function AppRoutes() {
       <Route path="/uchi-stock/:userId" element={<Home />} />
       <Route path="/item/:itemId" element={<ItemDetail />} />
       <Route path="/item/:itemId/update" element={<StockUpdate />} />
+      <Route path="/invite/manage" element={<FamilyInvite />} />
+      <Route path="/invite/:token" element={<InviteAccept />} />
     </Routes>
   );
 }

--- a/frontend/src/components/FamilyInvite.jsx
+++ b/frontend/src/components/FamilyInvite.jsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useUser } from "../contexts/UserContext";
+
+const FamilyInvite = () => {
+  const { userId, getIdToken } = useUser();
+  const [invitationToken, setInvitationToken] = useState("");
+  const [families, setFamilies] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copySuccess, setCopySuccess] = useState("");
+
+  const API_URL = import.meta.env.VITE_API_URL || "https://u8ix9o2m78.execute-api.ap-northeast-1.amazonaws.com/dev";
+
+  useEffect(() => {
+    fetchFamilies();
+  }, [userId]);
+
+  const fetchFamilies = async () => {
+    if (!userId || userId === 'pending') return;
+    try {
+      const token = await getIdToken();
+      const response = await fetch(`${API_URL}/families`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setFamilies(data);
+      }
+    } catch (err) {
+      console.error("Failed to fetch families", err);
+    }
+  };
+
+  const createInvitation = async () => {
+    setLoading(true);
+    setError("");
+    setCopySuccess("");
+    try {
+      const token = await getIdToken();
+      const response = await fetch(`${API_URL}/invitations`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("招待URLの発行に失敗しました");
+      }
+
+      const data = await response.json();
+      setInvitationToken(data.invitationToken);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const invitationUrl = invitationToken 
+    ? `${window.location.origin}${import.meta.env.BASE_URL}invite/${invitationToken}`
+    : "";
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(invitationUrl);
+    setCopySuccess("コピーしました！");
+    setTimeout(() => setCopySuccess(""), 3000);
+  };
+
+  return (
+    <div className="container py-4">
+      <div className="d-flex align-items-center mb-4">
+        <Link to="/" className="btn btn-outline-secondary me-3">
+          <i className="bi bi-arrow-left"></i>
+        </Link>
+        <h1 className="h3 mb-0">家族を招待・管理</h1>
+      </div>
+
+      <div className="card mb-4">
+        <div className="card-body">
+          <h2 className="h5 card-title mb-3">家族を招待する</h2>
+          <p className="card-text text-muted small">
+            招待URLを発行して家族に送ってください。相手がURLを開いてログインすると、お互いの在庫が共有されます。
+          </p>
+          
+          {!invitationToken ? (
+            <button 
+              className="btn btn-primary" 
+              onClick={createInvitation}
+              disabled={loading}
+            >
+              {loading ? "発行中..." : "招待URLを発行する"}
+            </button>
+          ) : (
+            <div>
+              <div className="input-group mb-2">
+                <input 
+                  type="text" 
+                  className="form-control" 
+                  value={invitationUrl} 
+                  readOnly 
+                />
+                <button 
+                  className="btn btn-outline-primary" 
+                  onClick={copyToClipboard}
+                >
+                  コピー
+                </button>
+              </div>
+              {copySuccess && <div className="text-success small mb-3">{copySuccess}</div>}
+              <button 
+                className="btn btn-link btn-sm p-0" 
+                onClick={() => setInvitationToken("")}
+              >
+                新しく発行する
+              </button>
+            </div>
+          )}
+          {error && <div className="alert alert-danger mt-3">{error}</div>}
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-body">
+          <h2 className="h5 card-title mb-3">登録済みの家族</h2>
+          {families.length === 0 ? (
+            <p className="text-muted small mb-0">まだ家族は登録されていません。</p>
+          ) : (
+            <ul className="list-group list-group-flush">
+              {families.map(member => (
+                <li key={member.userId} className="list-group-item d-flex align-items-center px-0">
+                  {member.photoURL ? (
+                    <img 
+                      src={member.photoURL} 
+                      alt={member.displayName} 
+                      className="rounded-circle me-3"
+                      style={{ width: "40px", height: "40px" }}
+                    />
+                  ) : (
+                    <div 
+                      className="rounded-circle bg-secondary d-flex align-items-center justify-content-center me-3 text-white"
+                      style={{ width: "40px", height: "40px" }}
+                    >
+                      {member.displayName.charAt(0)}
+                    </div>
+                  )}
+                  <div>
+                    <div className="fw-bold">{member.displayName}</div>
+                    <div className="text-muted small">{member.email}</div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FamilyInvite;

--- a/frontend/src/components/FamilyInvite.jsx
+++ b/frontend/src/components/FamilyInvite.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "../contexts/UserContext";
 
@@ -12,11 +12,7 @@ const FamilyInvite = () => {
 
   const API_URL = import.meta.env.VITE_API_URL || "https://u8ix9o2m78.execute-api.ap-northeast-1.amazonaws.com/dev";
 
-  useEffect(() => {
-    fetchFamilies();
-  }, [userId]);
-
-  const fetchFamilies = async () => {
+  const fetchFamilies = useCallback(async () => {
     if (!userId || userId === 'pending') return;
     try {
       const token = await getIdToken();
@@ -32,7 +28,11 @@ const FamilyInvite = () => {
     } catch (err) {
       console.error("Failed to fetch families", err);
     }
-  };
+  }, [userId, getIdToken, API_URL]);
+
+  useEffect(() => {
+    fetchFamilies();
+  }, [fetchFamilies]);
 
   const createInvitation = async () => {
     setLoading(true);

--- a/frontend/src/components/InviteAccept.jsx
+++ b/frontend/src/components/InviteAccept.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useUser } from "../contexts/UserContext";
 
@@ -11,13 +11,7 @@ const InviteAccept = () => {
 
   const API_URL = import.meta.env.VITE_API_URL || "https://u8ix9o2m78.execute-api.ap-northeast-1.amazonaws.com/dev";
 
-  useEffect(() => {
-    if (userId && userId !== 'pending' && userId !== 'test-user') {
-      acceptInvitation();
-    }
-  }, [userId]);
-
-  const acceptInvitation = async () => {
+  const acceptInvitation = useCallback(async () => {
     setLoading(true);
     setError("");
     try {
@@ -43,13 +37,19 @@ const InviteAccept = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [token, getIdToken, API_URL, navigate]);
+
+  useEffect(() => {
+    if (userId && userId !== 'pending' && userId !== 'test-user') {
+      acceptInvitation();
+    }
+  }, [userId, acceptInvitation]);
 
   const handleLogin = async () => {
     try {
       await login();
       // login() 成功後、userIdが更新され、useEffectでacceptInvitationが呼ばれる
-    } catch (err) {
+    } catch {
       setError("ログインに失敗しました");
     }
   };

--- a/frontend/src/components/InviteAccept.jsx
+++ b/frontend/src/components/InviteAccept.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useUser } from "../contexts/UserContext";
+
+const InviteAccept = () => {
+  const { token } = useParams();
+  const { userId, getIdToken, login } = useUser();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const API_URL = import.meta.env.VITE_API_URL || "https://u8ix9o2m78.execute-api.ap-northeast-1.amazonaws.com/dev";
+
+  useEffect(() => {
+    if (userId && userId !== 'pending' && userId !== 'test-user') {
+      acceptInvitation();
+    }
+  }, [userId]);
+
+  const acceptInvitation = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const idToken = await getIdToken();
+      const response = await fetch(`${API_URL}/invitations/accept`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify({ invitationToken: token }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.message || "招待の受諾に失敗しました");
+      }
+
+      // 成功したらホームへ
+      navigate("/");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLogin = async () => {
+    try {
+      await login();
+      // login() 成功後、userIdが更新され、useEffectでacceptInvitationが呼ばれる
+    } catch (err) {
+      setError("ログインに失敗しました");
+    }
+  };
+
+  return (
+    <div className="container py-5 text-center">
+      <div className="card shadow-sm mx-auto" style={{ maxWidth: "500px" }}>
+        <div className="card-body p-5">
+          <h1 className="h3 mb-4">家族への招待が届いています</h1>
+          
+          {loading ? (
+            <div className="py-4">
+              <div className="spinner-border text-primary mb-3" role="status">
+                <span className="visually-hidden">処理中...</span>
+              </div>
+              <p>家族登録を処理しています...</p>
+            </div>
+          ) : error ? (
+            <div className="py-4">
+              <div className="alert alert-danger mb-4">{error}</div>
+              <button className="btn btn-primary" onClick={() => navigate("/")}>
+                ホームへ戻る
+              </button>
+            </div>
+          ) : !userId || userId === 'pending' || userId === 'test-user' ? (
+            <div className="py-4">
+              <p className="mb-4">家族登録を完了するにはログインが必要です。</p>
+              <button className="btn btn-primary btn-lg w-100" onClick={handleLogin}>
+                Googleでログインして受諾する
+              </button>
+            </div>
+          ) : (
+            <div className="py-4">
+               <p>家族として登録しています...</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InviteAccept;

--- a/frontend/src/components/ItemDetail.jsx
+++ b/frontend/src/components/ItemDetail.jsx
@@ -1,13 +1,17 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useLocation } from "react-router-dom";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
 import { ArrowLeft, History as HistoryIcon, TrendingDown, Edit } from "lucide-react";
 import { useUser } from "../contexts/UserContext";
 
-const API_BASE_URL = "https://b974xlcqia.execute-api.ap-northeast-1.amazonaws.com/dev";
+const API_BASE_URL = import.meta.env.VITE_API_URL || "https://b974xlcqia.execute-api.ap-northeast-1.amazonaws.com/dev";
 
 const ItemDetail = () => {
   const { itemId } = useParams();
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const targetUserId = queryParams.get("userId");
+
   const [item, setItem] = useState(null);
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -36,7 +40,11 @@ const ItemDetail = () => {
 
     // アイテム情報の取得
     try {
-      const itemRes = await fetch(`${API_BASE_URL}/items`, { headers });
+      const url = new URL(`${API_BASE_URL}/items`);
+      if (targetUserId) {
+        url.searchParams.append("userId", targetUserId);
+      }
+      const itemRes = await fetch(url.toString(), { headers });
       if (itemRes.ok) {
         const itemsData = await itemRes.json();
         if (Array.isArray(itemsData)) {
@@ -53,7 +61,11 @@ const ItemDetail = () => {
 
     // 履歴の取得
     try {
-      const historyRes = await fetch(`${API_BASE_URL}/items/${itemId}/history`, { headers });
+      const url = new URL(`${API_BASE_URL}/items/${itemId}/history`);
+      if (targetUserId) {
+        url.searchParams.append("userId", targetUserId);
+      }
+      const historyRes = await fetch(url.toString(), { headers });
       if (historyRes.ok) {
         const historyData = await historyRes.json();
         setHistory(Array.isArray(historyData) ? historyData : []);
@@ -64,7 +76,11 @@ const ItemDetail = () => {
 
     // 推定データの取得
     try {
-      const estimateRes = await fetch(`${API_BASE_URL}/items/${itemId}/estimate`, { headers });
+      const url = new URL(`${API_BASE_URL}/items/${itemId}/estimate`);
+      if (targetUserId) {
+        url.searchParams.append("userId", targetUserId);
+      }
+      const estimateRes = await fetch(url.toString(), { headers });
       if (estimateRes.ok) {
         const estimateData = await estimateRes.json();
         setEstimate(estimateData);
@@ -72,7 +88,7 @@ const ItemDetail = () => {
     } catch (error) {
       console.error("Error fetching estimate:", error);
     }
-  }, [itemId, getHeaders, user, idToken]);
+  }, [itemId, getHeaders, user, idToken, targetUserId]);
 
   useEffect(() => {
     const initialFetch = async () => {
@@ -165,7 +181,10 @@ const ItemDetail = () => {
           </div>
           <div className="col-md-6">
             <div className="d-flex gap-2 justify-content-md-end">
-              <Link to={`/item/${itemId}/update`} className="btn btn-primary d-inline-flex align-items-center px-4 py-2">
+              <Link 
+                to={`/item/${itemId}/update${targetUserId ? `?userId=${targetUserId}` : ''}`} 
+                className="btn btn-primary d-inline-flex align-items-center px-4 py-2"
+              >
                 <Edit size={20} className="me-2" /> 在庫を更新する
               </Link>
             </div>


### PR DESCRIPTION
設計:
- 選定内容: DynamoDBに families テーブルと invitations テーブルを新設。招待URLを介した双方向共有モデルを採用。
- 却下内容: 単方向共有（招待者のみが共有）は利便性が低いため却下。
- 理由: 家族間では相互に在庫を更新できることが期待されるため。

影響:
- 影響モジュール: backend (handler, serverless), frontend (App, Home, ItemDetail, StockUpdate)
- 振る舞いの変更: 招待URLの発行・受諾が可能になり、登録された家族の在庫を切り替えて表示・更新できるようになった。

テスト:
- 追加済み: 既存テストの通過を確認。
- 未追加: 家族共有の新規APIテスト（後続で追加予定）。