### PR TITLE
feat(router): ログイン後もトップページ（LP）を表示できるように修正

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,7 @@ import { useUser } from "./contexts/UserContext";
 import "./App.css";
 
 function AppRoutes() {
-  const { userId, loading } = useUser();
+  const { loading } = useUser();
 
   if (loading) {
     return (
@@ -25,7 +25,7 @@ function AppRoutes() {
 
   return (
     <Routes>
-      <Route path="/" element={userId && userId !== 'test-user' && userId !== 'pending' ? <Navigate to={`${userId}`} replace /> : <Top />} />
+      <Route path="/" element={<Top />} />
       <Route path="/guide" element={<UserGuide />} />
       <Route path="/test-user" element={<Home />} />
       <Route path="/:userId" element={<Home />} />

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -66,7 +66,8 @@ function Home() {
   useEffect(() => {
     if (!authLoading && userId !== 'pending') {
       if (userId !== 'test-user') {
-        if (urlUserId !== userId) {
+        // userIdがURLに含まれていない（トップページなど）場合はリダイレクトしない
+        if (urlUserId && urlUserId !== userId) {
           navigate(`/${userId}`, { replace: true });
         }
       } else {

--- a/frontend/src/components/Top.jsx
+++ b/frontend/src/components/Top.jsx
@@ -15,7 +15,7 @@ function Top() {
   }, []);
 
   const handleStart = () => {
-    if (userId && userId !== 'test-user') {
+    if (userId && userId !== 'test-user' && userId !== 'pending') {
       navigate(`/${userId}`);
     } else {
       login();


### PR DESCRIPTION
設計:
- 選定内容: App.jsx での / パスにおける userId による Navigate を削除し、常に Top コンポーネントを表示するように変更。
- 却下内容: ログイン後にトップページにアクセスした際、自動的に在庫管理ページにリダイレクトする従来の挙動。
- 理由: ユーザーがログイン状態に関わらずサービス説明（トップページ）を確認できるようにするため。

影響:
- 影響モジュール: App.jsx, Top.jsx, Home.jsx
- 振る舞いの変更: ログイン中に / にアクセスしても自動リダイレクトされず、トップページが表示される。トップページの「利用開始」ボタンを押した際に、ログイン済みであれば在庫管理ページへ、未ログインであればログイン処理へ遷移する。

テスト:
- 追加済み: 既存のユニットテスト（App.test.jsx, Home.test.jsx）が通過することを確認。
- 未追加: N/A