### PR TITLE
fix(frontend): ログイン済みでもトップページにアクセスできるよう修正

### DIFF
--- a/frontend/e2e/top.spec.js
+++ b/frontend/e2e/top.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Top Page Redirection', () => {
+  test('should stay on top page even when logged in', async ({ page }) => {
+    // ログイン状態をシミュレートするために localStorage などを使いたいが、
+    // アプリケーションの実装に依存するため、
+    // ここではページロード後に userId がセットされるのを待つような挙動を考える。
+    // しかし、E2Eテスト環境ではデフォルトで 'test-user' になってしまう。
+    
+    // アプリケーションコードを変更する前に、現在の挙動を確認するためのテスト
+    // E2Eテスト環境ではデフォルトで userId='test-user' となるため、自動リダイレクトは発生しない。
+    // 今回の修正で、たとえログイン済みであってもトップページURLにアクセスした際は
+    // 自動リダイレクトされず、トップページが表示され続けることを目指している。
+
+    await page.goto('./');
+    
+    // トップページに留まることを確認
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText('利用開始')).toBeVisible();
+
+    // デモモードに入ってから、ヘッダーのロゴをクリックしてトップに戻れるか確認
+    await page.getByRole('button', { name: 'デモモード' }).click();
+    await expect(page).toHaveURL(/\/test-user/);
+
+    await page.click('h1:has-text("うちストック")');
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText('利用開始')).toBeVisible();
+  });
+});

--- a/frontend/src/components/Top.jsx
+++ b/frontend/src/components/Top.jsx
@@ -14,19 +14,20 @@ function Top() {
     return () => clearTimeout(timer);
   }, []);
 
-  const handleStart = () => {
+  const handleStart = async () => {
     if (userId && userId !== 'test-user' && userId !== 'pending') {
       navigate(`/${userId}`);
     } else {
-      login();
+      try {
+        const loggedInUser = await login();
+        if (loggedInUser) {
+          navigate(`/${loggedInUser.uid}`, { replace: true });
+        }
+      } catch (error) {
+        console.error("Login failed:", error);
+      }
     }
   };
-
-  useEffect(() => {
-    if (!authLoading && userId && userId !== 'test-user' && userId !== 'pending') {
-      navigate(`/${userId}`, { replace: true });
-    }
-  }, [userId, authLoading, navigate]);
 
   const handleDemo = () => {
     navigate("/test-user");

--- a/frontend/src/components/Top.test.jsx
+++ b/frontend/src/components/Top.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import Top from "./Top";
+import { UserContext } from "../contexts/UserContext";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("Top Component", () => {
+  const renderTop = (userContextValue) => {
+    return render(
+      <UserContext.Provider value={userContextValue}>
+        <BrowserRouter>
+          <Top />
+        </BrowserRouter>
+      </UserContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    vi.clearAllMocks();
+  });
+
+  it("does not redirect when userId is test-user", async () => {
+    const contextValue = {
+      userId: "test-user",
+      login: vi.fn(),
+      loading: false,
+    };
+    renderTop(contextValue);
+    
+    // リダイレクトされないことを確認
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByText("利用開始")).toBeInTheDocument();
+  });
+
+  it("does not redirect automatically even when userId is a real UID", async () => {
+    const contextValue = {
+      userId: "real-user-uid-123",
+      login: vi.fn(),
+      loading: false,
+    };
+    renderTop(contextValue);
+    
+    // 自動リダイレクトされないことを確認
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByText("利用開始")).toBeInTheDocument();
+  });
+
+  it("redirects after clicking start button when already logged in", async () => {
+    const contextValue = {
+      userId: "real-user-uid-123",
+      login: vi.fn(),
+      loading: false,
+    };
+    renderTop(contextValue);
+    
+    const startButton = screen.getByText("利用開始");
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.click(startButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/real-user-uid-123");
+  });
+
+  it("redirects after successful login when clicking start button", async () => {
+    const loginMock = vi.fn().mockResolvedValue({ uid: "new-real-user-uid" });
+
+    renderTop({
+      userId: "test-user",
+      login: loginMock,
+      loading: false,
+    });
+    
+    const startButton = screen.getByText("利用開始");
+    const { fireEvent } = await import("@testing-library/react");
+    await fireEvent.click(startButton);
+
+    expect(loginMock).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/new-real-user-uid", { replace: true });
+    });
+  });
+});

--- a/frontend/src/contexts/UserContext.test.jsx
+++ b/frontend/src/contexts/UserContext.test.jsx
@@ -24,10 +24,17 @@ vi.mock('../firebaseConfig', () => ({
 
 const TestComponent = () => {
   const { userId, login, logout } = useUser();
+  const handleLogin = async () => {
+    try {
+      await login();
+    } catch {
+      // Ignore in test component
+    }
+  };
   return (
     <div>
       <div data-testid="user-id">{userId}</div>
-      <button onClick={() => login()}>Login</button>
+      <button onClick={handleLogin}>Login</button>
       <button onClick={() => logout()}>Logout</button>
     </div>
   );

--- a/frontend/src/contexts/UserProvider.jsx
+++ b/frontend/src/contexts/UserProvider.jsx
@@ -62,8 +62,10 @@ export const UserProvider = ({ children }) => {
       provider.setCustomParameters({ prompt: 'select_account' });
       const result = await signInWithPopup(auth, provider);
       console.log('[UserProvider] Popup login success:', result.user.displayName);
+      return result.user;
     } catch (error) {
       console.error('[UserProvider] login error:', error);
+      throw error;
     }
   };
 


### PR DESCRIPTION
設計:
- 選定内容: Top.jsx の自動リダイレクトを削除し、ログイン成功時または明示的なボタンクリック時のみ遷移するよう変更。
- 却下内容: useEffect 内でのステート更新（lintエラー回避のため）。
- 理由: ユーザーがログイン状態でもランディングページやユーザーガイドを確認できるようにするため。

影響:
- 影響モジュール: Top.jsx, UserProvider.jsx
- 振る舞いの変更: ログイン済みで / にアクセスしても自動で /:userId に飛ばなくなる。

テスト:
- 追加済み: Top.test.jsx (ユニットテスト), top.spec.js (E2Eテスト)
- 未追加: N/A