### PR TITLE
feat(docs): ユーザーガイドに利用イメージを追記

### DIFF
--- a/frontend/src/components/UserGuide.jsx
+++ b/frontend/src/components/UserGuide.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { ChevronLeft, Info, HelpCircle, User, Users, ClipboardList } from "lucide-react";
+import { ChevronLeft, Info, HelpCircle, User, Users, ClipboardList, ShoppingBag, TrendingDown, ShieldAlert, Sparkles } from "lucide-react";
 
 function UserGuide() {
   return (
@@ -29,6 +29,58 @@ function UserGuide() {
                 日々の使用量を学習し、あと何日で在庫が切れるかを予測することで、
                 「トイレットペーパーを買い忘れた！」という悲劇を防ぎます。
               </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="col-12">
+          <div className="card shadow-sm border-0 border-start border-primary border-4">
+            <div className="card-body">
+              <h2 className="h5 card-title mb-4 d-flex align-items-center gap-2">
+                <Sparkles className="text-primary" />
+                こんな時に便利（利用イメージ）
+              </h2>
+              <div className="row g-4">
+                <div className="col-md-4">
+                  <div className="d-flex gap-3">
+                    <div className="bg-primary-subtle p-2 rounded-circle d-flex align-items-center justify-content-center" style={{ width: "48px", height: "48px", flexShrink: 0 }}>
+                      <ShoppingBag className="text-primary" size={24} />
+                    </div>
+                    <div>
+                      <h3 className="h6 fw-bold mb-2">ドラッグストアでの買い物に</h3>
+                      <p className="small text-muted mb-0">
+                        「あれ、まだあったっけ？」と迷う必要はありません。アプリを見れば現在の正確な在庫が分かり、今買うべき日用品がすぐに明確になります。
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-4">
+                  <div className="d-flex gap-3">
+                    <div className="bg-warning-subtle p-2 rounded-circle d-flex align-items-center justify-content-center" style={{ width: "48px", height: "48px", flexShrink: 0 }}>
+                      <TrendingDown className="text-warning" size={24} />
+                    </div>
+                    <div>
+                      <h3 className="h6 fw-bold mb-2">セールの買い溜め防止に</h3>
+                      <p className="small text-muted mb-0">
+                        特売品を見つけた時、今のストック量と消費予測を確認。買い溜めしすぎて収納スペースを圧迫するのを防げます。
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-4">
+                  <div className="d-flex gap-3">
+                    <div className="bg-success-subtle p-2 rounded-circle d-flex align-items-center justify-content-center" style={{ width: "48px", height: "48px", flexShrink: 0 }}>
+                      <ShieldAlert className="text-success" size={24} />
+                    </div>
+                    <div>
+                      <h3 className="h6 fw-bold mb-2">防災用品の備蓄管理に</h3>
+                      <p className="small text-muted mb-0">
+                        「ローリングストック」を賢く実践。日常的に使いながら備蓄する際、適切なストック量をコントロールしやすくなります。
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
設計:
- 選定内容: ユーザーガイドに「こんな時に便利（利用イメージ）」セクションを追加し、3つの具体的な利用シナリオを追記。
- 却下内容: テキストのみの追記。
- 理由: 視覚的な分かりやすさを向上させるため、lucide-reactのアイコンを組み合わせてカード形式で表示。

影響:
- 影響モジュール: frontend/src/components/UserGuide.jsx
- 振る舞いの変更: ユーザーガイドに具体的な利用シーンが表示されるようになる。

テスト:
- 追加済み: N/A
- 未追加: N/A