### PR TITLE
fix(frontend): ログイン状態でのデモモード表示不具合を修正

### DIFF
--- a/frontend/e2e/top.spec.js
+++ b/frontend/e2e/top.spec.js
@@ -1,28 +1,49 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Top Page Redirection', () => {
-  test('should stay on top page even when logged in', async ({ page }) => {
-    // ログイン状態をシミュレートするために localStorage などを使いたいが、
-    // アプリケーションの実装に依存するため、
-    // ここではページロード後に userId がセットされるのを待つような挙動を考える。
-    // しかし、E2Eテスト環境ではデフォルトで 'test-user' になってしまう。
-    
-    // アプリケーションコードを変更する前に、現在の挙動を確認するためのテスト
-    // E2Eテスト環境ではデフォルトで userId='test-user' となるため、自動リダイレクトは発生しない。
-    // 今回の修正で、たとえログイン済みであってもトップページURLにアクセスした際は
-    // 自動リダイレクトされず、トップページが表示され続けることを目指している。
-
+test.describe('Top Page and Demo Mode', () => {
+  test.beforeEach(async ({ page }) => {
+    // 常にトップページから開始
     await page.goto('./');
-    
-    // トップページに留まることを確認
+  });
+
+  test('should stay on top page and can navigate back from other pages', async ({ page }) => {
+    // 1. トップページに留まることを確認
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByText('利用開始')).toBeVisible();
 
-    // デモモードに入ってから、ヘッダーのロゴをクリックしてトップに戻れるか確認
-    await page.getByRole('button', { name: 'デモモード' }).click();
-    await expect(page).toHaveURL(/\/test-user/);
+    // 2. ユーザーガイド画面へ遷移
+    await page.click('button:has-text("使い方")');
+    await expect(page).toHaveURL(/\/guide/);
 
-    await page.click('h1:has-text("うちストック")');
+    // 3. ユーザーガイド独自の「戻る」ボタンをクリックしてトップに戻る
+    // (UserGuideには共通Headerが含まれていないため)
+    const backButton = page.locator('a:has-text("戻る")');
+    await backButton.waitFor({ state: 'visible' });
+    await backButton.click();
+    
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText('利用開始')).toBeVisible();
+  });
+
+  test('should display demo mode data and can navigate back', async ({ page }) => {
+    // 1. デモモードへ遷移
+    const demoButton = page.getByRole('button', { name: 'デモモード' });
+    await demoButton.waitFor({ state: 'visible' });
+    await demoButton.click();
+    
+    await expect(page).toHaveURL(/\/test-user/);
+    
+    // 2. デモデータが表示されていることを確認
+    // 複数の「トイレットペーパー」が存在する可能性があるため first() を使用
+    const demoItem = page.getByText('トイレットペーパー').first();
+    await demoItem.waitFor({ state: 'visible', timeout: 10000 });
+    await expect(demoItem).toBeVisible();
+
+    // 3. ヘッダーのロゴをクリックしてトップに戻る
+    const logoLink = page.locator('header a:has-text("うちストック")');
+    await logoLink.waitFor({ state: 'visible' });
+    await logoLink.click();
+    
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByText('利用開始')).toBeVisible();
   });

--- a/frontend/src/components/Header.test.jsx
+++ b/frontend/src/components/Header.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import Header from "./Header";
+import { UserContext } from "../contexts/UserContext";
+
+describe("Header Component", () => {
+  const renderHeader = (userContextValue = {}) => {
+    return render(
+      <UserContext.Provider value={{
+        user: null,
+        login: vi.fn(),
+        logout: vi.fn(),
+        loading: false,
+        ...userContextValue
+      }}>
+        <BrowserRouter>
+          <Header />
+        </BrowserRouter>
+      </UserContext.Provider>
+    );
+  };
+
+  it("renders the title and links to top page", () => {
+    renderHeader();
+    const titleLink = screen.getByRole("link", { name: /うちストック/i });
+    expect(titleLink).toBeInTheDocument();
+    expect(titleLink.getAttribute("href")).toBe("/");
+  });
+
+  it("displays login button when not logged in", () => {
+    renderHeader({ user: null });
+    expect(screen.getByText("ログイン")).toBeInTheDocument();
+  });
+
+  it("displays user info and logout button when logged in", () => {
+    const user = { displayName: "Test User", photoURL: null, uid: "uid123" };
+    renderHeader({ user });
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+    expect(screen.getByText("ログアウト")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -31,6 +31,12 @@ function Home() {
   const getHeaders = useCallback(() => {
     if (userId === 'pending') return null;
     
+    // 表示対象がデモユーザー（test-user）の場合は、ログイン状態に関わらず認証ヘッダーを送らない。
+    // これによりバックエンドはリクエストをデモユーザーのものとして処理する。
+    if (urlUserId === 'test-user' || selectedUserId === 'test-user') {
+      return { "x-user-id": "test-user" };
+    }
+
     const headers = {
       "x-user-id": userId
     };
@@ -38,7 +44,7 @@ function Home() {
       headers["Authorization"] = `Bearer ${idToken}`;
     }
     return headers;
-  }, [userId, idToken]);
+  }, [userId, idToken, urlUserId, selectedUserId]);
 
   const fetchFamilies = useCallback(async () => {
     try {

--- a/frontend/src/components/Home.test.jsx
+++ b/frontend/src/components/Home.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, MemoryRouter, Routes, Route } from "react-router-dom";
 import Home from "./Home";
 import { UserContext } from "../contexts/UserContext";
 
@@ -251,9 +251,6 @@ describe("Home Component", () => {
       idToken: "real-user-token",
       user: { uid: "real-user-uid" },
     };
-
-    // Use memory router to simulate /test-user path
-    const { MemoryRouter, Routes, Route } = await import("react-router-dom");
 
     render(
       <UserContext.Provider value={loggedInUserContext}>

--- a/frontend/src/components/Home.test.jsx
+++ b/frontend/src/components/Home.test.jsx
@@ -244,6 +244,39 @@ describe("Home Component", () => {
     });
   });
 
+  it("sends no authorization header when viewing demo-user even if logged in", async () => {
+    const loggedInUserContext = {
+      ...mockUserContext,
+      userId: "real-user-uid",
+      idToken: "real-user-token",
+      user: { uid: "real-user-uid" },
+    };
+
+    // Use memory router to simulate /test-user path
+    const { MemoryRouter, Routes, Route } = await import("react-router-dom");
+
+    render(
+      <UserContext.Provider value={loggedInUserContext}>
+        <MemoryRouter initialEntries={["/test-user"]}>
+          <Routes>
+            <Route path="/:userId" element={<Home />} />
+          </Routes>
+        </MemoryRouter>
+      </UserContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/items"),
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Authorization: expect.any(String),
+          }),
+        })
+      );
+    });
+  });
+
   it("displays fallback icon when photoURL is not available", async () => {
     const userWithoutPhoto = {
       ...mockUserContext,


### PR DESCRIPTION
設計:
- 選定内容: Home.jsx の getHeaders を修正し、デモモード表示時は認証ヘッダーを送らないよう変更。
- 理由: ログイン済みユーザーでもゲスト用のデモデータを正常に閲覧できるようにするため。

影響:
- 影響モジュール: Home.jsx, Top.jsx
- 振る舞いの変更: ログイン状態でも /test-user でデモデータが表示されるようになる。トップページへの復帰も可能。

テスト:
- 追加済み: Header.test.jsx (ユニットテスト), top.spec.js (E2Eテスト拡張)
- 未追加: N/A