### PR TITLE
fix(ci): 未定義入力enable_release_syncを削除しCI起動失敗を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,5 @@ jobs:
       backend_dir: backend
       node_version: "20"
       enable_e2e_test: true
-      enable_release_sync: false
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- `ci.yml`の`reusable-ci.yml`呼び出しから、dev-standards側で現在定義されていない入力`enable_release_sync: false`を削除
- 直近のRenovate PR（#144〜#151）がすべて`conclusion: startup_failure`（ジョブ0件）になっていた根本原因を修正（issue #159）

## 背景
未定義の`with:`入力を`workflow_call`のreusable workflowへ渡すと、ワークフロー自体がパース時点で無効と判定され、ジョブが1つも計画されずに`startup_failure`となる。`enable_release_sync`はこのPRの導入時点（#143、2026-07-05）では有効な入力だったが、`ci.yml`が`reusable-ci.yml@main`という固定されていないブランチ参照を使っているため、その後dev-standards側`main`のリリースモデル見直しでこの入力が削除・改名されたとみられる。この結果、commitlint等のテストjobも`merge` jobも一切起動しなくなり、PRの自動マージが完全に停止していた。

再発防止（`@main`ではなく固定タグを使う）は別issue（#160）として切り出し済みで、本PRのスコープには含めていない。

## Test plan
- [x] `python3`の`yaml`モジュールで`ci.yml`の構文妥当性を確認
- [ ] 本PR自体のCI実行で`commitlint`・`frontend-test`・`frontend-e2e-test`・`backend-test`が正常に起動・成功することを確認（GitHub Web/モバイルアプリのPR画面・Job Summaryで確認可能）
- [ ] 上記が成功した場合、`merge` jobによる自動マージが機能することを確認

Closes #159

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_