### PR TITLE
feat(e2e): E2Eテストにスクリーンショット報告機能を導入する

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 /playwright-report
 /test-results
+/e2e-screenshots
 
 # Editor directories and files
 .vscode/*

--- a/frontend/e2e/home.spec.js
+++ b/frontend/e2e/home.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { captureScreenshot } from './screenshot.js';
 
 test.describe('Home Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -39,19 +40,20 @@ test.describe('Home Page', () => {
     await demoButton.click();
   });
 
-  test('should display item list', async ({ page }) => {
+  test('should display item list', async ({ page }, testInfo) => {
     await expect(page.getByText('うちストック')).toBeVisible();
-    
+
     const itemCard = page.locator('.card').filter({ hasText: 'トイレットペーパー' });
     await expect(itemCard).toBeVisible();
     await expect(itemCard.getByText('5', { exact: true })).toBeVisible();
     await expect(itemCard.getByText('ロール', { exact: true })).toBeVisible();
-    
+
     // Use regex to be flexible with the exact number of days
     await expect(page.getByText(/あと約 \d+ 日/)).toBeVisible();
+    await captureScreenshot(page, testInfo, 'home-item-list', '品目一覧画面');
   });
 
-  test('should add a new item', async ({ page }) => {
+  test('should add a new item', async ({ page }, testInfo) => {
     // Mock POST /items
     await page.route('**/items', async (route) => {
       if (route.request().method() === 'POST') {
@@ -105,6 +107,7 @@ test.describe('Home Page', () => {
     await expect(newItemCard).toBeVisible();
     await expect(newItemCard.getByText('0', { exact: true })).toBeVisible();
     await expect(newItemCard.getByText('箱', { exact: true })).toBeVisible();
+    await captureScreenshot(page, testInfo, 'home-add-item', '品目追加後の一覧画面');
   });
 
   test.skip('should display past history date when it is not a prediction', async ({ page }) => {

--- a/frontend/e2e/item-detail.spec.js
+++ b/frontend/e2e/item-detail.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { captureScreenshot } from './screenshot.js';
 
 test.describe('Item Detail Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -51,7 +52,7 @@ test.describe('Item Detail Page', () => {
     await page.goto('item/item-1');
   });
 
-  test('should display item details and history', async ({ page }) => {
+  test('should display item details and history', async ({ page }, testInfo) => {
     // Wait for the page to load and display the item name
     // Use data-testid to uniquely identify the item name and avoid conflict with header title
     await expect(page.getByTestId('item-name')).toContainText('トイレットペーパー', { timeout: 10000 });
@@ -69,5 +70,6 @@ test.describe('Item Detail Page', () => {
     await expect(page.getByText('買い出し')).toBeVisible();
     await expect(page.getByText('12 ロール')).toBeVisible();
     await expect(page.getByText('購入')).toBeVisible();
+    await captureScreenshot(page, testInfo, 'item-detail', '品目詳細画面');
   });
 });

--- a/frontend/e2e/screenshot.js
+++ b/frontend/e2e/screenshot.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
+const SCREENSHOT_DIR = path.join(process.cwd(), 'e2e-screenshots');
+
+// dev-standardsのE2Eスクリーンショット報告機能（docs/cicd-pipeline-specification.md「1. CIワークフロー」参照）の
+// 呼び出し規約に従い、<frontend_dir>/e2e-screenshots/<name>.pngへPNGを書き出す。
+export async function captureScreenshot(page, testInfo, name, caption) {
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+  await page.screenshot({ path: path.join(SCREENSHOT_DIR, `${name}.png`) });
+
+  if (caption) {
+    fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.caption.txt`), caption, 'utf-8');
+  }
+
+  // テストケース単位の関連スクリーンショット折りたたみ判定に使う付随情報
+  fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.spec.txt`), path.basename(testInfo.file), 'utf-8');
+  fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.title.txt`), testInfo.title, 'utf-8');
+}

--- a/frontend/e2e/spec-source-map.json
+++ b/frontend/e2e/spec-source-map.json
@@ -1,0 +1,31 @@
+{
+  "top.spec.js": {
+    "should stay on top page and can navigate back from other pages": [
+      "frontend/src/components/Top.jsx",
+      "frontend/src/components/UserGuide.jsx"
+    ],
+    "should display demo mode data and can navigate back": [
+      "frontend/src/components/Top.jsx",
+      "frontend/src/components/DemoHome.jsx",
+      "frontend/src/components/Header.jsx"
+    ]
+  },
+  "home.spec.js": {
+    "should display item list": [
+      "frontend/src/components/DemoHome.jsx"
+    ],
+    "should add a new item": [
+      "frontend/src/components/DemoHome.jsx"
+    ]
+  },
+  "item-detail.spec.js": {
+    "should display item details and history": [
+      "frontend/src/components/ItemDetail.jsx"
+    ]
+  },
+  "stock-update.spec.js": {
+    "should allow entering consumption and purchase": [
+      "frontend/src/components/StockUpdate.jsx"
+    ]
+  }
+}

--- a/frontend/e2e/stock-update.spec.js
+++ b/frontend/e2e/stock-update.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { captureScreenshot } from './screenshot.js';
 
 test.describe('Stock Update Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -31,7 +32,7 @@ test.describe('Stock Update Page', () => {
     await page.goto('item/item-1/update');
   });
 
-  test('should allow entering consumption and purchase', async ({ page }) => {
+  test('should allow entering consumption and purchase', async ({ page }, testInfo) => {
     await expect(page.getByText('在庫を更新する')).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('トイレットペーパー')).toBeVisible();
 
@@ -45,6 +46,7 @@ test.describe('Stock Update Page', () => {
 
     // Enter memo
     await page.getByPlaceholder('例: 特売で購入').fill('テストメモ');
+    await captureScreenshot(page, testInfo, 'stock-update-form', '在庫更新フォーム入力画面');
 
     // Mock navigation after submit
     await page.route('**/items/*/history', async route => {

--- a/frontend/e2e/top.spec.js
+++ b/frontend/e2e/top.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { captureScreenshot } from './screenshot.js';
 
 test.describe('Top Page and Demo Mode', () => {
   test.beforeEach(async ({ page }) => {
@@ -6,14 +7,16 @@ test.describe('Top Page and Demo Mode', () => {
     await page.goto('./');
   });
 
-  test('should stay on top page and can navigate back from other pages', async ({ page }) => {
+  test('should stay on top page and can navigate back from other pages', async ({ page }, testInfo) => {
     // 1. トップページに留まることを確認
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByText('利用開始')).toBeVisible();
+    await captureScreenshot(page, testInfo, 'top-page', 'トップページ');
 
     // 2. ユーザーガイド画面へ遷移
     await page.click('button:has-text("使い方")');
     await expect(page).toHaveURL(/\/guide/);
+    await captureScreenshot(page, testInfo, 'top-guide', 'ユーザーガイド画面');
 
     // 3. ユーザーガイド独自の「戻る」ボタンをクリックしてトップに戻る
     // (UserGuideには共通Headerが含まれていないため)
@@ -25,7 +28,7 @@ test.describe('Top Page and Demo Mode', () => {
     await expect(page.getByText('利用開始')).toBeVisible();
   });
 
-  test('should display demo mode data and can navigate back', async ({ page }) => {
+  test('should display demo mode data and can navigate back', async ({ page }, testInfo) => {
     // 1. デモモードへ遷移
     const demoButton = page.getByRole('button', { name: 'デモモード' });
     await demoButton.waitFor({ state: 'visible' });
@@ -38,6 +41,7 @@ test.describe('Top Page and Demo Mode', () => {
     const demoItem = page.getByText('トイレットペーパー').first();
     await demoItem.waitFor({ state: 'visible', timeout: 10000 });
     await expect(demoItem).toBeVisible();
+    await captureScreenshot(page, testInfo, 'top-demo-mode', 'デモモード画面');
 
     // 3. ヘッダーのロゴをクリックしてトップに戻る
     const logoLink = page.locator('header a:has-text("うちストック")');


### PR DESCRIPTION
## Summary
- `frontend/e2e/screenshot.js`に`captureScreenshot(page, testInfo, name, caption)`ヘルパーを追加
- 既存4つのspecファイル（`top.spec.js`・`home.spec.js`・`item-detail.spec.js`・`stock-update.spec.js`）の成功パス主要箇所でスクリーンショットを撮影
- `frontend/e2e/spec-source-map.json`でテストケース単位の検証対象ソースパスを宣言（関連スクリーンショットの折りたたみ判定用）
- issue #154への対応

## 背景
dev-standards CLAUDE.md「開発環境の制約（スマホオンリー）」は、E2Eの視覚的確認にPlaywright HTMLレポート（アーティファクトzip、スマホからの閲覧が事実上困難）ではなく、`reusable-ci.yml`のE2Eスクリーンショット報告機能（Job Summary・PRコメントへ画像を直接埋め込み）を使うことを定めている。`ci.yml`は既に`enable_e2e_test: true`だが、既存4specは一切スクリーンショットを撮影しておらず、この機能が実質未導入だった。

## Test plan
- [x] ローカルで`npm run build`後、Playwrightを実行し、成功した5テストすべてで`<name>.png`・`<name>.caption.txt`・`<name>.spec.txt`・`<name>.title.txt`が意図通り生成されることを確認
- [x] 失敗した2テスト（`home.spec.js`「should add a new item」、`top.spec.js`「should display demo mode data...」）は、本変更を退避したベースライン（元のコード）でも同一のエラーで失敗することを確認済み。本変更起因ではなくローカル検証環境固有の問題（実際のデモAPI依存等）と判断。直近のPR #161ではGitHub Actions上の`frontend-e2e-test`ジョブ自体は成功している
- [ ] 本PR自体のGitHub Actions上でのE2E実行結果、Job Summary・PRコメントへのスクリーンショット埋め込みは、PR作成後のCI結果でGitHub Web/モバイルアプリから確認する

Closes #154

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_