### PR TITLE
fix(ci): reusable-ci.yml参照をmainブランチから固定タグへ変更する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@main
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.14.0
     with:
       frontend_dir: frontend
       backend_dir: backend


### PR DESCRIPTION
## Summary
- `ci.yml`の`uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@main`を`@v1.14.0`（dev-standards現時点の最新タグ）へ固定
- issue #160への対応

## 背景
issue #159（未定義入力`enable_release_sync`によるCI起動失敗）は、`ci.yml`が`reusable-ci.yml@main`という固定されていないブランチ参照を使っていたために、dev-standards側`main`の仕様変更が無告知でuchi-stockのCIへ即座に反映され発生した。dev-standards自身の`docs/cicd-pipeline-specification.md`「6. reusable workflow参照のバージョン固定」に、まさにこのリスクと固定タグ運用への切り替えが明記されている。

なお`renovate.json`が未導入（issue #153で別途対応予定）のため、現時点ではこのタグの更新PRはRenovateにより自動作成されない。#153のマージ後は`github-actions`マネージャーにより自動検知されるようになる。

## Test plan
- [x] `python3`の`yaml`モジュールで`ci.yml`の構文妥当性を確認
- [x] dev-standardsリポジトリで`v1.14.0`タグが実在し、参照先コミットがsubmodule参照コミットと同世代であることを確認
- [x] `cd.yml`に`dev-standards@`形式の参照が無いこと（影響範囲外）を確認
- [ ] 本PR自体のGitHub Actions上でのCI実行が正常に成功することの確認は、PR作成後のCI結果で行う

Closes #160

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_