### PR TITLE
feat(ci): CodeQLによる静的解析ワークフローを追加する

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,19 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-codeql.yml@v1.14.0
+    with:
+      languages: '["javascript-typescript"]'


### PR DESCRIPTION
## Summary
- `.github/workflows/codeql.yml`を新規作成し、dev-standardsの`reusable-codeql.yml@v1.14.0`を参照
- `on`に`push`（mainブランチ）・`pull_request`・`schedule`（毎週月曜3:17 UTC）を設定
- issue #156への対応

## 背景
dev-standardsはv1.8.0でCodeQLによる静的解析（SARIFをGitHub Securityタブへアップロード）を提供する`reusable-codeql.yml`を追加しているが、uchi-stockには`.github/workflows/codeql.yml`が存在せず未導入だった。このワークフローは`reusable-ci.yml`の`merge` jobのゲートには関与しない独立したワークフローで、`schedule`トリガー（コード変更が無い期間もクエリセット更新を検知するため推奨）は参照側の`codeql.yml`自体の`on:`で設定する必要がある。

## 追記（初回実行での不具合と修正）
初回のPR実行時、`codeql.yml`のワークフロー自体が`startup_failure`（ジョブ0件）になった。呼び出し元workflowにtop-level `permissions`を明示していなかったため、呼び出されるreusable workflow内jobが要求する権限（`security-events: write`等）を満たせなかったことが原因と判断し、`codeql.yml`のtop-levelにも同じ`permissions`を明示して解消した（同一PR上で修正・再検証済み）。

## Test plan
- [x] `python3`の`yaml`モジュールで`codeql.yml`の構文妥当性を確認
- [x] 初回実行が`startup_failure`（ジョブ0件）になることを確認し、top-level `permissions`追加により解消されることを同じPR上で再検証
- [ ] CodeQL解析が実際に成功し、GitHub Securityタブに結果が表示されることの確認は、修正後のCI実行結果およびSecurityタブでGitHub Web/モバイルアプリから行う

Closes #156

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa
