### PR TITLE
feat(ci): jscpdによるコード重複検知を有効化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
       backend_dir: backend
       node_version: "20"
       enable_e2e_test: true
+      enable_duplication_check: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- `ci.yml`の`reusable-ci.yml`呼び出しに`enable_duplication_check: true`を追加
- `duplication_threshold`は指定せず（既定0=ゲートなし）、まずレポート表示のみで実際の重複率を把握する
- issue #157への対応

## 背景
dev-standards CLAUDE.md「Reflection」節は完了前の確認事項として「重複コードはないか」を挙げているが、これまで人手（レビュー時の目視）に依存し自動化されていなかった。`reusable-ci.yml`はv1.9.0で`enable_duplication_check`（jscpdによるコード重複検知、Job Summaryへのレポート表示）を追加しているが、uchi-stockの`ci.yml`にはこの入力が指定されていなかった。

## Test plan
- [x] `python3`の`yaml`モジュールで`ci.yml`の構文妥当性を確認
- [ ] 本PR自体のGitHub Actions上で`duplication-check` jobが正常に起動・成功し、Job Summaryへ重複検知レポートが表示されることの確認は、PR作成後のCI結果でGitHub Web/モバイルアプリから行う

Closes #157

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_