### PR TITLE
fix(ci): run-nameでPR実行とpush-to-main実行を判別できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-run-name: CI ${{ github.event.head_commit.message || github.event.pull_request.title }}
+run-name: >-
+  CI (${{ github.event_name == 'pull_request' && 'PR' || 'push-to-main' }})
+  ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- `ci.yml`の`run-name`をdev-standards仕様書の推奨パターン（`github.event_name`に応じて「PR」「push-to-main」を先頭に付与）へ変更
- issue #158への対応

## 背景と重要な確認事項
issue #158は「`ci.yml`は`pull_request`と`push`（マージ後のmainへのpush）の両方で起動する」ことを前提としていましたが、実際に`ci.yml`の`on:`を確認したところ**`pull_request:`のみで`push:`トリガーは存在しません**。`cd.yml`はCI完了を`workflow_run`（`workflows: ["CI"]`）で監視する方式のため、`ci.yml`自体にpush直接トリガーは不要な構成になっています。

したがって、現時点では`run-name`の「push-to-main」側の分岐は実際には発火しません（常にPR側の表示になります）。この変更自体は無害で、dev-standards推奨パターンとの整合性・将来pushトリガーを追加する際の前方互換性のために採用しますが、issue #158が想定していた「実行一覧でPRとpushが混在して判別できない」という実害は、現状のuchi-stockでは発生していないことが判明しました。

## Test plan
- [x] `python3`の`yaml`モジュールで`ci.yml`の構文妥当性を確認
- [x] `ci.yml`の`on:`セクションを確認し`pull_request:`のみで`push:`が存在しないことを確認
- [ ] 本PR自体のGitHub Actions上で`run-name`が意図通り「CI (PR) ...」の形式で表示されることの確認は、PR作成後のCI結果でGitHub Web/モバイルアプリから行う

Closes #158

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_