### PR TITLE
feat(ci): docs/internal-design.mdのmermaid図を事前レンダリングする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,7 @@ jobs:
       node_version: "20"
       enable_e2e_test: true
       enable_duplication_check: true
+      enable_mermaid_render: true
+      mermaid_doc_paths: "docs/internal-design.md"
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- `ci.yml`の`reusable-ci.yml`呼び出しに`enable_mermaid_render: true`・`mermaid_doc_paths: "docs/internal-design.md"`を追加
- issue #155への対応

## 重要な制約（issue #155のスコープを一部見送った理由）
`render-mermaid-diagrams` jobの「`latest/`への恒久公開」ステップ（Markdown本体から`raw.githubusercontent.com`経由で常時参照できるようにする公開）は、`reusable-ci.yml`側で`github.event_name == 'push'`の場合のみ実行されます。issue #158の調査で確認した通り、uchi-stockの`ci.yml`は`on: pull_request:`のみで`push:`トリガーが存在しないため、この恒久公開ステップは**現状の構成では実行されません**。

つまり本PRで得られるのは「PRコメント上でのその場限りの確認」のみであり、issue #155が主目的とする「ドキュメント本体を開いた際に常に最新のレンダリング結果を確認できる」状態は実現できません。Markdown本体への画像埋め込みは`latest/`への恒久公開が機能して初めて意味を持つため、本PRでは行いません。

これはissue #154で導入したE2Eスクリーンショット機能の「前回バージョンとの画像diff」機能（同じく`push`イベント限定）にも共通する制約です。恒久公開・baseline比較を機能させるには`ci.yml`への`push`トリガー追加が必要なため、別issueとして切り出しました。

## Test plan
- [x] `python3`の`yaml`モジュールで`ci.yml`の構文妥当性を確認
- [x] `reusable-ci.yml`の`render-mermaid-diagrams` job実装を確認し、`latest/`公開ステップが`github.event_name == 'push'`限定であること、`ci.yml`に`push`トリガーが無いことを確認
- [ ] 本PR自体は`docs/internal-design.md`を変更していないため、PR変更ファイル判定によりレンダリング自体がスキップされる可能性が高い。実際に`docs/internal-design.md`を変更するPRでのPRコメント埋め込み確認は別途行う

Closes #155

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_