### PR TITLE
fix(backend): Lambdaランタイムをnodejs18.xからnodejs20.xへ更新する

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,7 +4,7 @@ useDotenv: true
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   region: ap-northeast-1
   environment:
     TABLE_NAME: ${self:custom.tableName}


### PR DESCRIPTION
## Summary
- `backend/serverless.yml`の`provider.runtime`を`nodejs18.x`から`nodejs20.x`へ更新
- AWS LambdaのNode.js 18.xは既にサポート終了期限（延長後でも2026-03）を過ぎており、
  既存Lambda関数の更新がAWS側で拒否される可能性がある状態だった
- `ci.yml`の`node_version`（`"20"`）と一致させ、CIで実際にテスト済みのバージョンに揃えた
- issue #181（OSLS移行）の検証中に発覚した副次的な問題への対応（issue #182）

## Test plan
- [x] backend配下で`npm run test`（vitest → lint → `serverless package --stage local-test`）
      を実行し、全50件のテストとパッケージングがランタイム警告なしで成功することを確認
- [ ] CI（`ci.yml`のbackend-test job）で同様に成功することを確認
- [ ] マージ後、`cd.yml`の`deploy-backend`（実際のAWS Lambdaデプロイ）が成功することを確認

Closes #182

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_