### PR TITLE
feat(ci): ci.ymlにmainへのpushトリガーを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ run-name: >-
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `ci.yml`の`on:`に`push: branches: [main]`を追加
- `reusable-ci.yml`のmermaid図・E2Eスクリーンショットの`latest/`baseline公開ステップは
  `github.event_name == 'push'`が条件のため、`pull_request`のみの現状では一度も
  実行されていなかった（issue #155・#154で導入した機能が未完成のまま）
- issue #178への対応

## 調査結果（影響範囲の確認）
- **二重マージのリスク**: 無し。`reusable-ci.yml`の`merge`ジョブは
  `github.event_name == 'pull_request'`を明示的に要求するため、push実行側では
  `merge`ジョブ自体が実行されない
- **CD（`cd.yml`）への影響**: マージ1回につき`ci.yml`の実行が2回（PR実行＋push実行）
  になるため、`workflow_run`をトリガーとする`cd.yml`も2回発火するようになる。
  ただし`cd.yml`には既に`concurrency: group: ${{ github.workflow }}-${{ github.ref }}`
  が設定されており、`github.ref`はworkflow_run発火時に常に`refs/heads/main`へ
  解決される（実行履歴のhead_branchフィールドで確認済み）ため、2回の発火は
  直列に処理される。1回目が実際のリリース・デプロイを行い、2回目は
  `semantic-release`が新規コミット無しとしてno-opする。ただし
  `build-and-deploy-frontend`/`deploy-backend`はrelease jobの成功のみを条件に
  無条件で走るため、2回目も同一内容の再デプロイが発生する（実害は無いが、
  マージ1回あたりのデプロイ時間・AWS API呼び出しが倍になる点は許容する
  トレードオフとする）

## Test plan
- [x] YAML構文をpython3の`yaml.safe_load`で検証
- [ ] マージ後、実際に`docs-diagrams`・`e2e-screenshots`ブランチの`latest/`が
      更新されることを確認
- [ ] マージ後、`cd.yml`が想定通り直列実行され、リリース・デプロイが
      二重に問題を起こさないことを確認

Closes #178

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_