### PR TITLE
refactor(cd): GitHub Pagesデプロイをdeploy-github-pages複合actionへ置き換える

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,10 +97,10 @@ jobs:
       # scripts/convert-changelog-to-json.jsはリポジトリに常駐させず、dev-standards側の
       # 最新版をCD実行のたびにコピーして使う（issue #233）
       - name: Checkout dev-standards (for the local composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: bamiyanapp/dev-standards
-          ref: v1.14.0
+          ref: v1.15.1
           path: .dev-standards-actions
       - name: Copy changelog-to-JSON conversion script
         uses: ./.dev-standards-actions/.github/actions/copy-changelog-script
@@ -123,40 +123,37 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy.outputs.page-url }}
+    # フロントエンドビルド用のsecretsは、複合action呼び出しステップの環境変数としてではなく
+    # job単位のenvとして設定する（複合action内部のrunステップへ確実に伝播させるため。
+    # 呼び出し元ステップのenv:はrunステップとは異なり複合action内部へ伝播しない）
+    env:
+      VITE_USER_POOL_ID: ${{ secrets.VITE_USER_POOL_ID }}
+      VITE_USER_POOL_CLIENT_ID: ${{ secrets.VITE_USER_POOL_CLIENT_ID }}
+      VITE_AUTH_DOMAIN: ${{ secrets.VITE_AUTH_DOMAIN }}
+      VITE_REDIRECT_SIGN_IN: ${{ secrets.VITE_REDIRECT_SIGN_IN }}
+      VITE_REDIRECT_SIGN_OUT: ${{ secrets.VITE_REDIRECT_SIGN_OUT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
+      - name: Checkout dev-standards (for the local composite action)
+        uses: actions/checkout@v7
         with:
-          node-version: 24
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
-      - name: Build
-        working-directory: frontend
-        run: npm run build
-        env:
-          VITE_USER_POOL_ID: ${{ secrets.VITE_USER_POOL_ID }}
-          VITE_USER_POOL_CLIENT_ID: ${{ secrets.VITE_USER_POOL_CLIENT_ID }}
-          VITE_AUTH_DOMAIN: ${{ secrets.VITE_AUTH_DOMAIN }}
-          VITE_REDIRECT_SIGN_IN: ${{ secrets.VITE_REDIRECT_SIGN_IN }}
-          VITE_REDIRECT_SIGN_OUT: ${{ secrets.VITE_REDIRECT_SIGN_OUT }}
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+          repository: bamiyanapp/dev-standards
+          ref: v1.15.1
+          path: .dev-standards-actions
+      - name: 🚀 Build and Deploy to GitHub Pages
+        id: deploy
+        uses: ./.dev-standards-actions/.github/actions/deploy-github-pages
         with:
-          path: frontend/dist
-      - name: 🚀 Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          working-directory: frontend
+          node-version: "24"
+          artifact-path: frontend/dist
       - name: Show GitHub Pages URL
         run: |
-          echo "Pages URL: ${{ steps.deployment.outputs.page_url }}"
+          echo "Pages URL: ${{ steps.deploy.outputs.page-url }}"
 
   deploy-backend:
     needs: release


### PR DESCRIPTION
## Summary
- `build-and-deploy-frontend` jobの手書き5ステップ（setup-node→npm ci→build→
  upload-pages-artifact→deploy-pages）を、dev-standardsの`deploy-github-pages`
  複合actionの呼び出しへ置き換えた
- 併せて`changelog` jobのdev-standards参照タグを`v1.14.0`→`v1.15.1`、
  `actions/checkout`を`v7`へ揃えた（`ci.yml`/`codeql.yml`と一致させた）
- `deploy-pages@v4`→`v5`のズレ（Renovateが`cd.yml`の直書きステップを更新できて
  いなかった）も複合action化により解消される
- issue #234への対応

## Test plan
- [x] `python3`の`yaml.safe_load`でcd.ymlの構文を検証
- [ ] マージ後、実際にGitHub Pagesが従来通り更新されることを確認する

Closes #234

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_