### PR TITLE
fix: ルートpackage.jsonのname/repositoryをuchi-stock向けに修正する

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "karuta-root",
+  "name": "uchi-stock-root",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/bamiyanapp/karuta.git"
+    "url": "https://github.com/bamiyanapp/uchi-stock.git"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.966.0",


### PR DESCRIPTION
## Summary
- ルート`package.json`の`name`（`karuta-root`）・`repository.url`
  （`bamiyanapp/karuta.git`）が、CI/CD共通化スキャフォールディング時のコピー元
  （別リポジトリkaruta）のまま残っていたため、uchi-stock向けに修正した
- `.releaserc.cjs`が`repositoryUrl`を独自に明示指定しているため実害は無かったが、
  事実として誤ったメタデータだった
- 未使用のdevDependencies（`@semantic-release/changelog`・`exec`・`git`・`npm`）の
  要否はissue #236（release-config.cjs採用検討）の結論待ちのため、今回は対応しない
- issue #235への対応

## Test plan
- [x] `python3`の`json.load`でpackage.jsonの構文を検証

Closes #235

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_