### PR TITLE
chore(ci): CIのnode_versionとLambdaランタイムをNode 22へ引き上げる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       frontend_dir: frontend
       backend_dir: backend
-      node_version: "20"
+      node_version: "22"
       enable_e2e_test: true
       enable_duplication_check: true
       enable_mermaid_render: true

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,7 +4,7 @@ useDotenv: true
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs22.x
   region: ap-northeast-1
   environment:
     TABLE_NAME: ${self:custom.tableName}


### PR DESCRIPTION
## Summary
- `ci.yml`の`node_version`を`"20"`から`"22"`へ、`backend/serverless.yml`の
  `provider.runtime`を`nodejs20.x`から`nodejs22.x`へ引き上げた
- issue #182で確立した「CI検証用Node.jsバージョンとLambdaランタイムを一致させる」
  方針を踏襲し、今回も両者を揃えた
- `firebase-admin` v14（要Node>=22）・`jsdom` v30（要Node 22.22+/24.15+/26+）等、
  Node 20固定のCIでブロックされていた依存更新（PR #225・#216）が今後通せるようになる
- issue #252への対応

## Test plan
- [x] ローカル（Node v22.22.2）でbackend配下`npm ci`からやり直し、
      `npm run test`（vitest → lint → `serverless package --stage local-test`）が
      ランタイム警告なしで成功することを確認
- [x] ローカルでfrontend配下`npm ci`からやり直し、`npm run lint`・
      `npx vitest run --coverage`・`npm run build`が全て成功することを確認
      （`@testing-library/jest-dom@7.0.1`のEBADENGINE警告が解消されたことも確認）
- [ ] CI（`ci.yml`のfrontend-test/backend-test/frontend-e2e-test job）で
      同様に成功することを確認
- [ ] マージ後、`cd.yml`の`deploy-backend`（実際のAWS Lambdaデプロイ、
      nodejs22.xランタイムでの実デプロイ）が成功することを確認

Closes #252

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_