### PR TITLE
docs(design): internal-design.mdへmermaid図の恒久画像埋め込みを追加する

### DIFF
--- a/docs/internal-design.md
+++ b/docs/internal-design.md
@@ -109,6 +109,8 @@ sequenceDiagram
     S-->>B: Aの在庫データを返却
 ```
 
+![家族招待シーケンス図](https://raw.githubusercontent.com/bamiyanapp/uchi-stock/docs-diagrams/latest/internal-design-1.png)
+
 ---
 
 ## 6. システム構成 (Architecture)
@@ -134,6 +136,8 @@ graph TD
     I -- API Request with ID Token --> J;
 ```
 
+![システム構成図](https://raw.githubusercontent.com/bamiyanapp/uchi-stock/docs-diagrams/latest/internal-design-2.png)
+
 ### 画面遷移図
 
 ```mermaid
@@ -154,6 +158,8 @@ graph TD
     Any --> |存在しないパス/品目| NotFound[NotFound 画面]
     NotFound --> |「在庫一覧に戻る」をクリック| Home
 ```
+
+![画面遷移図](https://raw.githubusercontent.com/bamiyanapp/uchi-stock/docs-diagrams/latest/internal-design-3.png)
 
 ### 画面一覧
 


### PR DESCRIPTION
## Summary
- `docs/internal-design.md`内の3箇所の```mermaid```ブロック直後に、
  `docs-diagrams`ブランチの`latest/`（issue #178のpushトリガー追加により
  mainへのpushのたびに自動更新される）を参照する画像を追加した
- issue #155で当初意図していた「PR差分ビュー・GitHub CLI/API経由での
  ファイル取得等でも図を画像として確認できる」状態を完成させた
- issue #254への対応

## Test plan
- [x] 3枚の画像URL（`raw.githubusercontent.com/.../docs-diagrams/latest/
      internal-design-{1,2,3}.png`）がいずれもHTTP 200で疎通することを
      curlで確認
- [ ] GitHubモバイルアプリから画像がタップ拡大表示できることを確認する

Closes #254

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_