### PR TITLE
fix(e2e): デモモードのAPIレスポンスをモックし実バックエンド依存を除去する

### DIFF
--- a/frontend/e2e/top.spec.js
+++ b/frontend/e2e/top.spec.js
@@ -29,6 +29,35 @@ test.describe('Top Page and Demo Mode', () => {
   });
 
   test('should display demo mode data and can navigate back', async ({ page }, testInfo) => {
+    // デモモードは実際のバックエンド（test-userの共有データ）を参照するため、
+    // 他PRのCIが並行して同じデータを操作すると本テストが不安定化する
+    // （issue #307）。他specと同様にAPIレスポンスをモックして独立させる。
+    // StockList.jsxはuserId確定後に`?userId=test-user`付きで再フェッチする
+    // ため、末尾に`*`を付けクエリ文字列の有無どちらにもマッチさせる
+    await page.route('**/items*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            itemId: 'demo-item-1',
+            name: 'トイレットペーパー',
+            currentStock: 5,
+            unit: 'ロール',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ]),
+      });
+    });
+
+    await page.route('**/items/demo-item-1/estimate*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ estimatedDepletionDate: null }),
+      });
+    });
+
     // 1. デモモードへ遷移
     const demoButton = page.getByRole('button', { name: 'デモモード' });
     await demoButton.waitFor({ state: 'visible' });


### PR DESCRIPTION
## Summary
- `frontend/e2e/top.spec.js`の「デモモード」テストが、他specと違い実バックエンド（`StockList.jsx`のデフォルト`API_BASE_URL`＝共有`dev`ステージ）に直接依存しており、共有`test-user`データの不安定さの影響を受けて、オープン中の複数PR（#306, #305, #304, #302, #301, #299, #216）すべてで内容に関わらず同一テストが失敗しマージが詰まっていた
- 他spec（`stock-update.spec.js`・`item-detail.spec.js`）と同様に`page.route`でAPIレスポンスをモックし、実バックエンドへの依存を除去した
- `StockList.jsx`は`userId`確定後に`?userId=test-user`付きで再フェッチするため、モックのURLパターン末尾に`*`を付与しクエリ文字列の有無どちらにもマッチするようにした（ローカルでPlaywrightを実際に実行し、当初のパターンでは2回目のリクエストがマッチせずローディングが止まったままになることを特定・修正済み）

## Test plan
- [x] ローカルで`npx playwright test e2e/top.spec.js`を実行し、対象テスト2件とも成功することを確認済み
- [x] `npm run test`（vitest 33件・lint・build）が成功することを確認済み

Closes #307

Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_