### PR TITLE
feat(pwa): Service Worker導入でアプリ更新の反映を改善する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
       enable_duplication_check: true
       enable_mermaid_render: true
       mermaid_doc_paths: "docs/internal-design.md"
+      enable_standards_check: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -29,4 +29,15 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    // sw.js（dev-standardsからsymlink）・sw-config.jsはService Worker専用の
+    // グローバル（self・importScripts・caches等）を使うため、上記のbrowser/node
+    // globalsとは別にserviceworker globalsを適用する
+    files: ['public/sw.js', 'public/sw-config.js'],
+    languageOptions: {
+      globals: {
+        ...globals.serviceworker,
+      },
+    },
+  },
 ])

--- a/frontend/public/sw-config.js
+++ b/frontend/public/sw-config.js
@@ -1,0 +1,17 @@
+// sw.js（dev-standardsからsymlink）のプロダクト固有設定。
+// docs/service-worker-update-pattern.md参照。
+self.SW_CONFIG = {
+  // sw.js・sw-config.jsの内容やprecacheUrls等のキャッシュ戦略を変更した際は
+  // 必ず値を変更し、activate時に旧キャッシュを確実に破棄させること
+  cacheVersion: "v1",
+  // インストール時に先読みキャッシュするページ一覧。GitHub Pagesのプロジェクト
+  // サイトとしてサブパス（/uchi-stock/）配信のため、絶対パスにはこのサブパスを含める
+  precacheUrls: ["/uchi-stock/"],
+  // バックエンドAPI（b974xlcqia.execute-api.ap-northeast-1.amazonaws.com）は
+  // x-user-id/Authorizationヘッダーでユーザーごとに異なるレスポンスを返す。
+  // Cache StorageのキーはURLのみでヘッダーを考慮しないため、Stale-While-Revalidate
+  // 対象に含めると別ユーザーのレスポンスを返してしまう恐れがある。そのため
+  // 空のままキャッシュ対象外とし、常にネットワークへ直接流す
+  apiHostnames: [],
+  noCacheSameOriginPrefixes: [],
+};

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,1 @@
+../../dev-standards/shared/pwa/sw.js

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,8 @@ import Changelog from "./components/Changelog";
 import NotFound from "./components/NotFound";
 import { UserProvider } from "./contexts/UserProvider";
 import { useUser } from "./contexts/UserContext";
+import ServiceWorkerRegistration from "./components/ServiceWorkerRegistration";
+import UpdateNotifier from "./components/UpdateNotifier";
 import "./App.css";
 
 function AppRoutes() {
@@ -46,6 +48,8 @@ function App() {
   const basename = import.meta.env.MODE === 'test' ? '/' : import.meta.env.BASE_URL;
   return (
     <UserProvider>
+      <ServiceWorkerRegistration />
+      <UpdateNotifier />
       <Router basename={basename}>
         <AppRoutes />
       </Router>

--- a/frontend/src/components/ServiceWorkerRegistration.jsx
+++ b/frontend/src/components/ServiceWorkerRegistration.jsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+
+// dev-standards（shared/pwa/ServiceWorkerRegistration.jsx）からのsymlinkではなく
+// 個別コピー。uchi-stockはGitHub Pagesのプロジェクトサイト（vite.config.jsの
+// base: "/uchi-stock/"）としてサブパス配信されており、共有版がハードコードしている
+// register("/sw.js")（サイトルート配信前提）ではスコープが合わない
+// （issue #319）。import.meta.env.BASE_URLを使いサブパス配下のsw.jsを登録する
+// 点のみが差分で、それ以外のロジックは共有版と同一。
+//
+// iOS PWA（ホーム画面から起動したスタンドアロン表示）はブラウザの自動的な
+// Service Worker更新チェック（ページ遷移時・約24時間おき）が働きにくく、
+// アプリを終了せずバックグラウンドへ回して再度開いただけでは新バージョンに
+// 気づかないことがある。アプリがフォアグラウンドに戻るたびに明示的に
+// registration.update()を呼び、新バージョンの検知（UpdateNotifierが拾う
+// controllerchangeイベント）を確実にする。詳細な経緯・キャッシュ戦略の全体像は
+// dev-standards/docs/service-worker-update-pattern.mdを参照
+const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+export default function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+
+    let registration;
+    navigator.serviceWorker
+      .register(`${import.meta.env.BASE_URL}sw.js`)
+      .then((reg) => {
+        registration = reg;
+      })
+      .catch((error) => {
+        console.error("Service Worker registration failed", error);
+      });
+
+    function checkForUpdate() {
+      if (document.visibilityState === "visible") {
+        registration?.update().catch(() => {
+          // オフライン等での更新チェック失敗は致命的ではないため無視する
+        });
+      }
+    }
+
+    document.addEventListener("visibilitychange", checkForUpdate);
+    const intervalId = setInterval(checkForUpdate, UPDATE_CHECK_INTERVAL_MS);
+
+    return () => {
+      document.removeEventListener("visibilitychange", checkForUpdate);
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/ServiceWorkerRegistration.test.jsx
+++ b/frontend/src/components/ServiceWorkerRegistration.test.jsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ServiceWorkerRegistration from './ServiceWorkerRegistration';
+
+describe('ServiceWorkerRegistration', () => {
+  let registerMock;
+
+  beforeEach(() => {
+    registerMock = vi.fn().mockResolvedValue({ update: vi.fn() });
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { register: registerMock },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete navigator.serviceWorker;
+    vi.restoreAllMocks();
+  });
+
+  it('registers sw.js under import.meta.env.BASE_URL (GitHub Pagesのサブパス配信に対応するため)', () => {
+    render(<ServiceWorkerRegistration />);
+    expect(registerMock).toHaveBeenCalledWith(`${import.meta.env.BASE_URL}sw.js`);
+  });
+
+  it('does nothing when serviceWorker is not supported', () => {
+    delete navigator.serviceWorker;
+    expect(() => render(<ServiceWorkerRegistration />)).not.toThrow();
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/UpdateNotifier.jsx
+++ b/frontend/src/components/UpdateNotifier.jsx
@@ -1,0 +1,1 @@
+../../../dev-standards/shared/pwa/UpdateNotifier.jsx

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: "/uchi-stock/",
+  // dev-standards/shared/pwa/UpdateNotifier.jsxをsymlink共有しており、reactを
+  // importしている。Viteは既定でシンボリックリンクの実体パス（dev-standards配下）を
+  // 起点にnode_modulesを探索してしまうため、preserveSymlinksが必須
+  // （dev-standards/docs/shared-ui-components.md参照）
+  resolve: {
+    preserveSymlinks: true,
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/sync-manifest.local.json
+++ b/sync-manifest.local.json
@@ -1,0 +1,6 @@
+{
+  "symlinks": [
+    { "source": "shared/pwa/sw.js", "target": "frontend/public/sw.js" },
+    { "source": "shared/pwa/UpdateNotifier.jsx", "target": "frontend/src/components/UpdateNotifier.jsx" }
+  ]
+}


### PR DESCRIPTION
## Summary
- ホーム画面に追加した状態でアプリを更新（デプロイ）しても古い内容が表示され続け、削除・再追加しないと最新化されない問題（issue #319）に対応
- 原因はService Worker・キャッシュ更新の仕組みが一切導入されていなかったこと。dev-standardsの標準PWAキャッシュ更新パターン（`shared/pwa/`、`docs/service-worker-update-pattern.md`）を導入した
- `sw.js`・`UpdateNotifier.jsx`は`sync-manifest.local.json`経由でsymlink。`ServiceWorkerRegistration.jsx`は共有版そのままでは使えないため個別コピー（uchi-stockはGitHub Pagesのプロジェクトサイトとしてサブパス配信（`base: "/uchi-stock/"`）のため、`register("/sw.js")`ではスコープが合わず、`register(\`${import.meta.env.BASE_URL}sw.js\`)`へ変更）
- `frontend/public/sw-config.js`（新規）：`apiHostnames`は空にした。バックエンドAPIはユーザーごとに異なるレスポンスを返すが、Cache StorageのキーはURLのみでヘッダーを考慮しないため、キャッシュ対象に含めると別ユーザーのレスポンスを返してしまう恐れがあるため
- `resolve.preserveSymlinks: true`（`vite.config.js`）・`sw.js`用のESLint `serviceworker` globals（`eslint.config.js`）も、symlink共有・Service Worker特有のグローバルに対応するため追加

## Test plan
- [x] ローカルでPlaywrightを使い実際に`http://localhost:4173/uchi-stock/`へアクセスし、Service Workerが`scope: "http://localhost:4173/uchi-stock/"`・`active: "http://localhost:4173/uchi-stock/sw.js"`で正しく登録・activateされることを確認済み
- [x] `frontend/src/components/ServiceWorkerRegistration.test.jsx`（新規）を追加し、BASE_URL配下でsw.jsを登録すること・serviceWorker未対応環境でクラッシュしないことを確認
- [x] `npm run test`（vitest 35件・lint・build）が成功することを確認済み
- [x] `npx playwright test`（既存e2e）を実行し、今回の変更による新規失敗が無いことを確認済み

Closes #319

Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_