### PR TITLE
chore: dev-standardsの.claude/settings.json・skills・.gitignoreを再同期する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,1 @@
+../dev-standards/.claude/settings.json

--- a/.claude/skills/code-review
+++ b/.claude/skills/code-review
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/code-review

--- a/.claude/skills/commit
+++ b/.claude/skills/commit
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/commit

--- a/.claude/skills/development-loop
+++ b/.claude/skills/development-loop
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/development-loop

--- a/.claude/skills/git-workflow
+++ b/.claude/skills/git-workflow
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/git-workflow

--- a/.claude/skills/loop-budget
+++ b/.claude/skills/loop-budget
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/loop-budget

--- a/.claude/skills/loop-triage
+++ b/.claude/skills/loop-triage
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/loop-triage

--- a/.claude/skills/loop-verifier
+++ b/.claude/skills/loop-verifier
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/loop-verifier

--- a/.claude/skills/minimal-fix
+++ b/.claude/skills/minimal-fix
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/minimal-fix

--- a/.claude/skills/planning-and-task-breakdown
+++ b/.claude/skills/planning-and-task-breakdown
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/planning-and-task-breakdown

--- a/.claude/skills/verifier
+++ b/.claude/skills/verifier
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/verifier

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
+# --- dev-standards managed: start ---
+# このマーカー区間はdev-standards側との完全一致チェック対象（scripts/bootstrap.js、issue #138）。
+# プロダクト固有の追加エントリは、この区間の外（後ろ）に追記すること。
 # Node dependencies
 node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 yarn.lock
-
-# Serverless
-.serverless/
 
 # Build outputs
 dist/
@@ -27,6 +27,13 @@ Thumbs.db
 # Environment variables
 .env
 .env.*
+
+# commit skill が下書きに使う一時ファイル
+commit_msg*.txt
+# --- dev-standards managed: end ---
+
+# Serverless
+.serverless/
 
 # Backup files
 backend/karuta-phrases-backup.json


### PR DESCRIPTION
## Summary
- `node dev-standards/scripts/bootstrap.js`を実行し、欠落していた`.claude/settings.json`・`.claude/skills/*`（code-review、commit、development-loop、git-workflow、loop-budget、loop-triage、loop-verifier、minimal-fix、planning-and-task-breakdown、verifier）のsymlinkを作成
- `.gitignore`はdev-standards管理区間（`# --- dev-standards managed: start/end ---`）のマーカーを追加し、dev-standards側と内容を完全一致させたうえで、uchi-stock固有のエントリ（Serverless・Backup files）をマーカー区間の外（末尾）へ再配置

issue #319（PWA対応）作業中に、これらのsymlinkが長期間欠落していたことが判明したため、別途対応。

## Test plan
- [x] `node dev-standards/scripts/bootstrap.js --check`が19/19件OKになることを確認済み
- [x] frontend/backendともに`npm run test`（lint・test・build）が成功することを確認済み

Closes #321

Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_