### PR TITLE
feat(header): ログアウトをユーザーメニューへ集約しアプリ共有を追加する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "firebase": "^12.8.0",
         "lucide-react": "^1.0.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0",
@@ -1544,9 +1545,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1564,9 +1562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1584,9 +1579,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1604,9 +1596,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1624,9 +1613,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1644,9 +1630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4064,9 +4047,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4088,9 +4068,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4112,9 +4089,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4136,9 +4110,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5271,6 +5242,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/re2js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "firebase": "^12.8.0",
     "lucide-react": "^1.0.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -1,0 +1,20 @@
+.user-menu-dropdown {
+  min-width: 220px;
+  z-index: 1050;
+}
+
+.dropdown-item-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: 0.875rem;
+}
+
+.dropdown-item-btn:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,21 +1,37 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import { Users, User as UserIcon } from "lucide-react";
+import React, { useState, useEffect, useRef } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Users, User as UserIcon, LogOut } from "lucide-react";
 import { useUser } from "../contexts/UserContext";
-import { useNavigate } from "react-router-dom";
+import ShareButton from "./ShareButton";
+import "./Header.css";
 
 const Header = () => {
   const navigate = useNavigate();
   const authContext = useUser() || {};
-  const { 
-    user = null, 
-    login = () => {}, 
-    logout = () => {}, 
-    loading: authLoading = false 
+  const {
+    user = null,
+    login = () => {},
+    logout = () => {},
+    loading: authLoading = false
   } = authContext;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  // メニュー外をクリックした場合に閉じる
+  useEffect(() => {
+    if (!menuOpen) return;
+    function handleClickOutside(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [menuOpen]);
 
   const handleLogout = async () => {
     try {
+      setMenuOpen(false);
       await logout();
       navigate("/", { replace: true });
     } catch (error) {
@@ -34,7 +50,7 @@ const Header = () => {
             </Link>
           )}
         </div>
-        
+
         <div className="header-center">
           <Link to="/" className="text-decoration-none">
             <h1 className="h4 m-0 fw-bold text-primary">うちストック</h1>
@@ -45,23 +61,43 @@ const Header = () => {
           {authLoading ? (
             <div className="spinner-border spinner-border-sm text-secondary" role="status"></div>
           ) : user ? (
-            <div className="d-flex align-items-center gap-2">
-              <div className="user-info d-flex align-items-center gap-2">
+            <div className="user-menu position-relative" ref={menuRef}>
+              <button
+                type="button"
+                onClick={() => setMenuOpen((prev) => !prev)}
+                className="btn btn-sm btn-outline-secondary d-flex align-items-center gap-2"
+                aria-expanded={menuOpen}
+                aria-label="ユーザーメニュー"
+              >
                 {user.photoURL ? (
-                  <img 
-                    src={user.photoURL} 
-                    alt={user.displayName || "User"} 
-                    className="rounded-circle border"
-                    style={{ width: '28px', height: '28px', objectFit: 'cover' }}
+                  <img
+                    src={user.photoURL}
+                    alt={user.displayName || "User"}
+                    className="rounded-circle"
+                    style={{ width: '24px', height: '24px', objectFit: 'cover' }}
                   />
                 ) : (
-                  <div className="bg-light rounded-circle d-flex align-items-center justify-content-center border" style={{ width: '28px', height: '28px' }}>
-                    <UserIcon size={14} className="text-muted" />
-                  </div>
+                  <UserIcon size={16} />
                 )}
-                <span className="small text-muted d-none d-md-inline">{user.displayName || user.email || user.uid}</span>
-              </div>
-              <button onClick={handleLogout} className="btn btn-sm btn-outline-secondary">ログアウト</button>
+                <span className="small d-none d-md-inline">{user.displayName || user.email || user.uid}</span>
+              </button>
+
+              {menuOpen && (
+                <div className="user-menu-dropdown position-absolute end-0 mt-2 bg-white rounded shadow border py-1">
+                  <div className="px-3 py-2 border-bottom small text-muted text-truncate">
+                    {user.displayName || user.email || user.uid}
+                  </div>
+                  <ShareButton
+                    label="アプリを共有"
+                    className="dropdown-item-btn"
+                    getUrl={() => window.location.origin + import.meta.env.BASE_URL}
+                  />
+                  <button type="button" onClick={handleLogout} className="dropdown-item-btn text-danger">
+                    <LogOut size={16} />
+                    ログアウト
+                  </button>
+                </div>
+              )}
             </div>
           ) : (
             <div className="d-flex align-items-center gap-2">

--- a/frontend/src/components/Header.test.jsx
+++ b/frontend/src/components/Header.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { BrowserRouter } from "react-router-dom";
 import Header from "./Header";
@@ -33,10 +33,32 @@ describe("Header Component", () => {
     expect(screen.getByText("ログイン")).toBeInTheDocument();
   });
 
-  it("displays user info and logout button when logged in", () => {
+  it("hides logout button and share button until the user menu is opened", () => {
     const user = { displayName: "Test User", photoURL: null, uid: "uid123" };
     renderHeader({ user });
     expect(screen.getByText("Test User")).toBeInTheDocument();
+    expect(screen.queryByText("ログアウト")).not.toBeInTheDocument();
+    expect(screen.queryByText("アプリを共有")).not.toBeInTheDocument();
+  });
+
+  it("displays logout button and share button after opening the user menu", () => {
+    const user = { displayName: "Test User", photoURL: null, uid: "uid123" };
+    renderHeader({ user });
+
+    fireEvent.click(screen.getByRole("button", { name: "ユーザーメニュー" }));
+
     expect(screen.getByText("ログアウト")).toBeInTheDocument();
+    expect(screen.getByText("アプリを共有")).toBeInTheDocument();
+  });
+
+  it("calls logout when the logout button in the menu is clicked", async () => {
+    const logout = vi.fn().mockResolvedValue();
+    const user = { displayName: "Test User", photoURL: null, uid: "uid123" };
+    renderHeader({ user, logout });
+
+    fireEvent.click(screen.getByRole("button", { name: "ユーザーメニュー" }));
+    fireEvent.click(screen.getByText("ログアウト"));
+
+    expect(logout).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { Share2 } from "lucide-react";
+
+// dev-standards/shared/ui/ShareButton.jsxを個別コピーしたもの（symlinkではない）。
+// 共有版はdaisyUI固有のクラス名（modal/modal-open/modal-box/btn等）を前提にしており、
+// uchi-stockはBootstrap 5.3構成（Bootstrap JS本体は読み込んでおらずCSSのみ）のため
+// そのままでは無スタイルになる。UpdateNotifier.jsxと同様、独自のposition-fixed
+// オーバーレイ＋Bootstrapユーティリティクラスへ書き換えた個別コピーとして管理する
+// （dev-standards/docs/shared-ui-components.md「daisyUI固有のクラス名を使う共有
+// コンポーネントを流用する場合」参照）。
+//
+// 現在のページ（既定ではwindow.location.href）をQRコードで表示し、URLをワンタップ
+// コピーできるボタン＋モーダル。スマートフォンオンリーの利用環境で、家族間の
+// 画面共有にQRコードの読み取りが最も簡便であることを想定している。
+//
+// label: トリガーボタン・モーダル見出しの文言
+// className: トリガーボタンへ追加するクラス名（メニュー項目等、埋め込み先の見た目に合わせる）
+// getUrl: 共有するURLを返す関数（既定はwindow.location.href）
+export default function ShareButton({ label = "アプリを共有", className = "", getUrl = () => window.location.href }) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [shareUrl, setShareUrl] = useState("");
+
+  function openShare() {
+    setCopied(false);
+    setShareUrl(getUrl());
+    setOpen(true);
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+    } catch {
+      // クリップボードAPIが使えない環境では、URLのテキスト選択・手動コピーで代替する
+    }
+  }
+
+  return (
+    <>
+      <button type="button" onClick={openShare} className={className}>
+        <Share2 size={16} />
+        {label}
+      </button>
+
+      {open && (
+        <div
+          className="position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center p-3"
+          style={{ backgroundColor: "rgba(0, 0, 0, 0.5)", zIndex: 1090 }}
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-3 shadow p-4"
+            style={{ maxWidth: "320px", width: "100%" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="h5 fw-bold mb-3">{label}</h3>
+            <div className="my-4 d-flex justify-content-center">
+              <QRCodeSVG value={shareUrl} size={200} />
+            </div>
+            <p className="bg-light rounded p-2 small text-break user-select-all">{shareUrl}</p>
+            <div className="d-flex justify-content-end gap-2 mt-3">
+              <button type="button" className="btn btn-sm btn-primary" onClick={handleCopy}>
+                {copied ? "コピーしました" : "URLをコピー"}
+              </button>
+              <button type="button" className="btn btn-sm btn-outline-secondary" onClick={() => setOpen(false)}>
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/ShareButton.test.jsx
+++ b/frontend/src/components/ShareButton.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ShareButton from "./ShareButton";
+
+describe("ShareButton Component", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  it("does not show the QR code modal until clicked", () => {
+    render(<ShareButton getUrl={() => "https://example.com/uchi-stock/"} />);
+    expect(screen.queryByText("URLをコピー")).not.toBeInTheDocument();
+  });
+
+  it("shows the QR code and URL when the trigger button is clicked", () => {
+    render(<ShareButton getUrl={() => "https://example.com/uchi-stock/"} />);
+    fireEvent.click(screen.getByText("アプリを共有"));
+    expect(screen.getByText("https://example.com/uchi-stock/")).toBeInTheDocument();
+    expect(screen.getByText("URLをコピー")).toBeInTheDocument();
+  });
+
+  it("copies the URL to the clipboard and shows a confirmation", async () => {
+    render(<ShareButton getUrl={() => "https://example.com/uchi-stock/"} />);
+    fireEvent.click(screen.getByText("アプリを共有"));
+    fireEvent.click(screen.getByText("URLをコピー"));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://example.com/uchi-stock/");
+    expect(await screen.findByText("コピーしました")).toBeInTheDocument();
+  });
+
+  it("closes the modal when the close button is clicked", () => {
+    render(<ShareButton getUrl={() => "https://example.com/uchi-stock/"} />);
+    fireEvent.click(screen.getByText("アプリを共有"));
+    fireEvent.click(screen.getByText("閉じる"));
+    expect(screen.queryByText("URLをコピー")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ユーザーアイコンをクリックすると開くドロップダウンメニューへログアウトボタンを移動（従来は常時表示）
- ドロップダウンに「アプリを共有」を追加。クリックするとQRコード＋URLコピー可能なモーダルが開く（共有URLはアプリのトップページ）
- `ShareButton.jsx`はdev-standardsの`shared/ui/ShareButton.jsx`を参考にした個別コピー。uchi-stockはBootstrap 5.3 CSSのみでBootstrap JS本体を読み込んでおらず、共有版のdaisyUIクラス名もそのままでは機能しないため、独自のposition-fixedオーバーレイ＋Bootstrapユーティリティクラスへ書き換えた

## Test plan
- [x] `npm run test`（vitest 41件・lint・build）が成功することを確認済み
- [x] `npx playwright test`（既存e2e）を実行し、今回の変更による新規失敗が無いことを確認済み
- [x] ローカルでHeaderを実際にBootstrap CSS込みでレンダリングし、メニュー開閉・QRコード共有モーダルの見た目をスクリーンショットで目視確認済み

Closes #323

Claude-Session: https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_