### PR TITLE
fix(cd): build-and-deploy-frontendのcheckoutでdev-standards submoduleを取得する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,10 +134,16 @@ jobs:
       VITE_REDIRECT_SIGN_IN: ${{ secrets.VITE_REDIRECT_SIGN_IN }}
       VITE_REDIRECT_SIGN_OUT: ${{ secrets.VITE_REDIRECT_SIGN_OUT }}
     steps:
+      # PR #320でfrontend/src/components/UpdateNotifier.jsx・frontend/public/sw.jsを
+      # dev-standards submodule（shared/pwa/）へのsymlinkとして追加した。submodules: true
+      # を指定しないとリンク先が存在せずViteビルドがUNRESOLVED_IMPORTで失敗する
+      # （issue #333、CI側は既にenable_standards_check: trueで対応済みだったが
+      # cd.yml側の同種のcheckoutには反映漏れがあった）
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          submodules: true
       - name: Checkout dev-standards (for the local composite action)
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## 背景

PR #320（issue #319）でPWA対応のため`frontend/src/components/UpdateNotifier.jsx`・`frontend/public/sw.js`をdev-standards submodule（`shared/pwa/`）へのsymlinkとして追加した。CI側は`enable_standards_check: true`を設定しsubmoduleを取得するようにしたが、`cd.yml`の`build-and-deploy-frontend`ジョブのcheckoutステップにはこの対応が漏れていた。

その結果、mainへのマージ後、CDの`build-and-deploy-frontend`ジョブが直近の実行すべてで以下のエラーによりビルド失敗し続けている。

```
[UNRESOLVED_IMPORT] Could not resolve './components/UpdateNotifier' in src/App.jsx
```

Closes #333

## 変更内容

`cd.yml`の`build-and-deploy-frontend`ジョブの最初のCheckoutステップへ`submodules: true`を追加した。

## 影響範囲

- CDの`build-and-deploy-frontend`ジョブのみ変更。dev-standards submoduleを取得するようになり、frontendのビルドが成功しGitHub Pagesへのデプロイが再開する

## Test plan

- [x] `git submodule update --init --recursive`でsymlink先（`UpdateNotifier.jsx`・`sw.js`）が実際に存在することを確認
- [x] frontendの`npm run test`（vitest 41件・lint・build）が成功することを確認
- [x] YAML構文をpython3の`yaml`モジュールでパース確認
- [ ] マージ後、実際のCD実行（Actionsタブ、スマートフォンのブラウザから確認可能）で`build-and-deploy-frontend`が成功しGitHub Pagesへのデプロイが完了することを確認する


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_