### PR TITLE
feat(top): トップページにバージョン・更新日時を表示する

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,6 +18,10 @@ export default defineConfig([
       globals: {
         ...globals.browser,
         ...globals.node,
+        // vite.config.jsのdefineでビルド時に埋め込むグローバル定数
+        // （dev-standards/shared/ui/getAppVersionDefine.js参照）
+        __APP_VERSION__: 'readonly',
+        __APP_BUILD_TIME__: 'readonly',
       },
       parserOptions: {
         ecmaVersion: 'latest',

--- a/frontend/getAppVersionDefine.js
+++ b/frontend/getAppVersionDefine.js
@@ -1,0 +1,1 @@
+../dev-standards/shared/ui/getAppVersionDefine.js

--- a/frontend/src/components/Top.css
+++ b/frontend/src/components/Top.css
@@ -241,3 +241,9 @@
   font-size: 0.9rem;
   color: #999;
 }
+
+.top-footer-version {
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: #bbb;
+}

--- a/frontend/src/components/Top.jsx
+++ b/frontend/src/components/Top.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useUser } from "../contexts/UserContext";
 import topImage from "../assets/top.png";
+import formatBuildTime from "./formatBuildTime.js"; // symlink
 import "./Top.css";
 
 function Top() {
@@ -98,6 +99,9 @@ function Top() {
 
       <footer className="top-footer">
         <p>&copy; 2026 uchi-stock</p>
+        <p className="top-footer-version">
+          v{__APP_VERSION__} / 更新日時: {formatBuildTime(__APP_BUILD_TIME__)}
+        </p>
       </footer>
     </div>
   );

--- a/frontend/src/components/formatBuildTime.js
+++ b/frontend/src/components/formatBuildTime.js
@@ -1,0 +1,1 @@
+../../../dev-standards/shared/ui/formatBuildTime.js

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import getAppVersionDefine from './getAppVersionDefine.js' // symlink
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,6 +12,13 @@ export default defineConfig({
   // （dev-standards/docs/shared-ui-components.md参照）
   resolve: {
     preserveSymlinks: true,
+  },
+  // __APP_VERSION__・__APP_BUILD_TIME__をビルド時に埋め込む
+  // （dev-standards/docs/frontend-ui-conventions.md「トップページの必須構成」）。
+  // frontend/package.jsonではなくリポジトリルートのpackage.jsonを参照する
+  // （semantic-releaseがバージョンを更新する対象がルート側のため）
+  define: {
+    ...getAppVersionDefine(new URL('../package.json', import.meta.url)),
   },
   test: {
     environment: 'jsdom',

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
   "scripts": {
     "release:local": "./scripts/local-release.sh"
   },
-  "version": "1.14.0"
+  "version": "1.50.1"
 }

--- a/sync-manifest.local.json
+++ b/sync-manifest.local.json
@@ -1,6 +1,8 @@
 {
   "symlinks": [
     { "source": "shared/pwa/sw.js", "target": "frontend/public/sw.js" },
-    { "source": "shared/pwa/UpdateNotifier.jsx", "target": "frontend/src/components/UpdateNotifier.jsx" }
+    { "source": "shared/pwa/UpdateNotifier.jsx", "target": "frontend/src/components/UpdateNotifier.jsx" },
+    { "source": "shared/ui/getAppVersionDefine.js", "target": "frontend/getAppVersionDefine.js" },
+    { "source": "shared/ui/formatBuildTime.js", "target": "frontend/src/components/formatBuildTime.js" }
   ]
 }


### PR DESCRIPTION
## 背景

dev-standardsの`docs/frontend-ui-conventions.md`「トップページの必須構成」により、各プロダクトのトップページにバージョン・更新日時の表示が必須とされている。dev-standards PR #340で、この表示を実装するための共有ヘルパー`shared/ui/getAppVersionDefine.js`・`shared/ui/formatBuildTime.js`が追加された。

Closes #339

## 変更内容

- `sync-manifest.local.json`へ`getAppVersionDefine.js`・`formatBuildTime.js`のsymlinkエントリを追加
- `frontend/vite.config.js`で`getAppVersionDefine.js`を呼び出し、**リポジトリルート**の`package.json`（`frontend/package.json`ではない）を参照して`__APP_VERSION__`・`__APP_BUILD_TIME__`を`define`へ埋め込む
- `frontend/src/components/Top.jsx`のフッターへ`v{__APP_VERSION__} / 更新日時: {formatBuildTime(__APP_BUILD_TIME__)}`を表示
- `frontend/eslint.config.js`へ`__APP_VERSION__`・`__APP_BUILD_TIME__`のglobals定義を追加（`no-undef`回避）
- ルート`package.json`の`version`を、実際の最新リリース（`v1.50.1`）へ補正（`1.14.0`のまま長期間更新されていなかった）

## 既知の制約・フォローアップ

ルート`package.json`の`version`は`.releaserc.cjs`に`@semantic-release/npm`が無いため、リリースのたびに自動更新される仕組みがない。今回は表示が直ちに誤った値にならないよう手動で最新リリースへ補正したが、今後のリリースで再び乖離しうる。自動同期の仕組み導入は別途フォローアップとして検討する。

## Test plan

- [x] `npm run test`（vitest 41件・lint・build）が成功することを確認
- [x] `node dev-standards/scripts/bootstrap.js --check`が23/23件OKになることを確認
- [x] ビルド成果物（`dist/assets/index-*.js`）に実際のバージョン文字列が埋め込まれていることを確認
- [x] ローカルで`npm run preview`を起動しPlaywrightで実際にフッターのテキストを取得し、「v1.50.1 / 更新日時: 2026/08/30 11:03」のように正しく表示されることを確認
- [ ] マージ後、実際にデプロイされたトップページ（スマートフォンのブラウザから確認可能）でバージョン・更新日時が表示されることを確認する


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_