### PR TITLE
fix(cd): run-nameがコミットSHAのみで内容がわからない問題を解消する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,10 @@
 name: CD
-run-name: CD ${{ github.event.workflow_run.head_sha }}
+# dev-standardsのCD run-name規約（docs/cicd-pipeline-specification.md
+# 「2. CDワークフロー」）に倣い、コミットSHAの羅列ではなく内容が分かる
+# 表示にする（issue #337）
+run-name: >-
+  CD (${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }})
+  ${{ github.event.workflow_run.head_commit.message }}
 
 on:
   workflow_run:


### PR DESCRIPTION
## 背景

`cd.yml`（`workflow_run`トリガー）の`run-name`が`github.event.workflow_run.head_sha`（コミットSHAのみ）になっており、GitHub ActionsのRun一覧（スマートフォンのブラウザから確認する運用）でどの変更に対応するCD実行かひと目で分からなかった。

dev-standards側でCD run-nameの規約（トリガー方式ごとの推奨パターン）を新設し（[bamiyanapp/dev-standards#345](``https://github.com/bamiyanapp/dev-standards/pull/345)）、'workflow_run'トリガー向けには'github.event.workflow_run.head_commit.message'（トリガー元CI実行のコミットメッセージ）を使うことが定められた。``

Closes #337

## 変更内容

`cd.yml`の`run-name`を、dev-standardsの規約に沿って`github.event.workflow_run.head_commit.message`を含む形へ変更した。

## 影響範囲

- CDワークフローのRun一覧の表示名のみの変更。release/deploy処理自体に変更は無い

## Test plan

- [x] python3の`yaml`モジュールでYAML構文をパース確認
- [x] `node dev-standards/scripts/bootstrap.js --check`が23/23件OKになることを確認
- [ ] actionlintはローカルで未実行（dev-standards側のnode_modulesが本リポジトリから参照できないため）。CIの`standards-check`ジョブでの検証結果を確認する
- [ ] マージ後、実際のCD実行（Actionsタブ、スマートフォンのブラウザから確認可能）でrun-nameにコミットメッセージが表示されることを確認する


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_