### PR TITLE
fix(share): アプリ共有モーダルでQRコードが見切れる問題を修正する

### DIFF
--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -50,9 +50,14 @@ export default function ShareButton({ label = "アプリを共有", className = 
           style={{ backgroundColor: "rgba(0, 0, 0, 0.5)", zIndex: 1090 }}
           onClick={() => setOpen(false)}
         >
+          {/* iOS Safariでアドレスバー表示時・横向き等でビューポート高が
+              低くなると、見出し＋QR＋URL＋ボタンの合計高がoverflow escapeの
+              手段なしに画面をはみ出し、QRコードが見切れて操作できなくなって
+              いた（issue #347）。maxHeight+overflowYでモーダル内スクロールへ
+              フォールバックさせる */}
           <div
             className="bg-white rounded-3 shadow p-4"
-            style={{ maxWidth: "320px", width: "100%" }}
+            style={{ maxWidth: "320px", width: "100%", maxHeight: "90vh", overflowY: "auto" }}
             onClick={(e) => e.stopPropagation()}
           >
             <h3 className="h5 fw-bold mb-3">{label}</h3>


### PR DESCRIPTION
## 背景

アプリ共有機能（ユーザーメニュー→「アプリを共有」）で表示されるQRコードモーダルが、ビューポート高が不足する状況（iOS Safariのアドレスバー表示時、横向き表示等）で画面をはみ出し、QRコードが見切れて全部表示されない不具合が報告された。

Closes #347

## 原因

モーダル本体（`bg-white rounded-3 shadow p-4`）に高さの上限・overflow制御が無く、オーバーレイの`align-items-center`により、見出し＋QR＋URL＋ボタンの合計高がビューポートを超えた場合に上下均等にはみ出していた。escapeする手段（スクロール等）が存在しなかった。

## 変更内容

モーダル本体へ`maxHeight: 90vh`・`overflowY: auto`を追加し、ビューポート高が不足する場合はモーダル内スクロールへフォールバックするようにした。

## Test plan

- [x] `npm run test`（vitest 41件・lint・build）が成功することを確認
- [ ] 実際のiOS Safari実機・低いビューポート高での見た目確認は未実施（ShareButtonはログイン後のユーザーメニューからのみ到達可能で、認証をモックしたE2Eの構築が必要なため）。マージ後、実機での確認をお願いしたい


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_