### PR TITLE
fix(auth): ログインセッションが頻繁に切れる問題を軽減する

### DIFF
--- a/frontend/src/contexts/UserContext.test.jsx
+++ b/frontend/src/contexts/UserContext.test.jsx
@@ -15,6 +15,8 @@ vi.mock('firebase/auth', () => ({
   signInWithRedirect: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  setPersistence: vi.fn(() => Promise.resolve()),
+  browserLocalPersistence: {},
 }));
 
 // Mock firebaseConfig

--- a/frontend/src/contexts/UserProvider.jsx
+++ b/frontend/src/contexts/UserProvider.jsx
@@ -1,7 +1,27 @@
 import React, { useState, useEffect } from 'react';
-import { GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged } from 'firebase/auth';
+import { GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged, setPersistence, browserLocalPersistence } from 'firebase/auth';
 import { auth } from '../firebaseConfig';
 import { UserContext } from './UserContext';
+
+// ホーム画面に追加したPWA（standalone表示）は、iOS SafariのITP
+// （Intelligent Tracking Prevention）により、一定期間操作が無いと
+// IndexedDB・localStorage等のスクリプト書き込み可能なストレージが
+// 消去されることがある。Firebase AuthのセッションもIndexedDBへ永続化
+// されているため、これに巻き込まれてログインセッションが意図せず
+// 切れる（issue #326）。navigator.storage.persist()でブラウザに
+//永続ストレージを要求することで、この自動消去の対象になりにくくする
+// （Safari 15.2+でサポート、未対応環境ではAPI自体が存在しないため
+// フィーチャー検出で無視する。付与されるかはブラウザの裁量であり
+// 確実な保証ではない）
+async function requestPersistentStorage() {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.storage?.persist) {
+      await navigator.storage.persist();
+    }
+  } catch (error) {
+    console.warn('[UserProvider] storage.persist() failed:', error);
+  }
+}
 
 const isE2E = import.meta.env.MODE === 'test';
 const isDev = import.meta.env.MODE === 'development';
@@ -22,6 +42,11 @@ export const UserProvider = ({ children }) => {
       console.log('[UserProvider] Auth skipping (E2E or no API key)');
       return;
     }
+
+    requestPersistentStorage();
+    setPersistence(auth, browserLocalPersistence).catch((error) => {
+      console.warn('[UserProvider] setPersistence failed:', error);
+    });
 
     console.log('[UserProvider] Registering onAuthStateChanged');
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -25,4 +25,6 @@ vi.mock('firebase/auth', () => ({
     callback(null);
     return () => {};
   }),
+  setPersistence: vi.fn(() => Promise.resolve()),
+  browserLocalPersistence: {},
 }));


### PR DESCRIPTION
## 背景

ログインセッションが毎回切れる不具合が報告された。本アプリはiOS Safariのホーム画面に追加して使う運用（CLAUDE.md「開発環境の制約（スマホオンリー）」）だが、iOS SafariのITP（Intelligent Tracking Prevention）は、一定期間操作の無いstandalone表示のPWAに対し、IndexedDB等のスクリプト書き込み可能なストレージを消去することがある。Firebase AuthのセッションはIndexedDBに永続化されているため、これに巻き込まれて意図せずログアウト状態になっていたと考えられる。

Refs #326

## 変更内容

- `UserProvider.jsx`で、Firebase Authの永続化方式を明示的に`setPersistence(auth, browserLocalPersistence)`へ設定
- `navigator.storage.persist()`（フィーチャー検出付き）でブラウザに永続ストレージを要求し、iOS Safariの自動ストレージ消去の対象になりにくくする

バックエンド側（`backend/handler.js`）のID Token検証も確認したが、`checkRevoked`無しの標準的な検証のみで、短いセッションTTLを強制する実装は見当たらず、根本原因ではないと判断した。

## 影響範囲

- アプリ起動時に`navigator.storage.persist()`を要求するようになる（対応ブラウザのみ、UIへの影響は無い）
- Firebase Authの永続化方式が明示的に`browserLocalPersistence`になる（従来のSDKデフォルトと同じ設定のため実質的な挙動変化は無い想定）

## 既知の限界

`navigator.storage.persist()`が実際にiOS Safariでのストレージ消去を防ぐかどうかは、付与判定がOS・ブラウザ内部のヒューリスティクスに委ねられており、確実な保証ではない。マージ後、実際にセッションが長く保持されるかを実機で確認いただきたい。改善しない場合は、再ログインの手間を減らす方向（例: ログインボタンをより見つけやすくする等）での追加対応を検討する。

## Test plan

- [x] `npm run test`（vitest 41件・lint・build）が成功することを確認
- [ ] マージ後、実際にiOS Safari実機でログインセッションの持続時間が改善したかを数日単位で確認する（スマートフォンから確認可能）


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_