### PR TITLE
fix(cd): トップページのバージョン表示が実際のリリースと乖離する問題を修正する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -75,6 +77,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           DEBUG: semantic-release:*
         run: npx semantic-release
+      # .releaserc.cjsに@semantic-release/npmが無くpackage.jsonのversionは
+      # 更新されないため、実際にリリースされたバージョンをgit tagから
+      # 取得する。このジョブのチェックアウトはコミットしないため、
+      # git historyには一切影響しない（issue #348、frontend側で
+      # トップページに表示するバージョンがpackage.json更新の仕組み
+      # 不在によりリリースのたびに乖離していた問題への対応）
+      - name: Get released version
+        id: get-version
+        run: |
+          TAG=$(git tag --points-at HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$TAG" ]; then
+            # このpushではリリース対象のコミット（feat/fix等）が無く新規
+            # タグが発行されなかった。その場合は既存の最新タグ（＝現在
+            # 実際にデプロイされているバージョン）を使う
+            TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')
+          fi
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
   changelog:
     needs: release
@@ -155,6 +174,22 @@ jobs:
           repository: bamiyanapp/dev-standards
           ref: v1.15.1
           path: .dev-standards-actions
+      # frontend/getAppVersionDefine.js（symlink）がビルド時にルートの
+      # package.jsonのversionを読み込みトップページへ埋め込む（issue #339）。
+      # package.jsonのversionはreleaseジョブでは更新されないため、実際に
+      # リリースされたバージョン（releaseジョブのoutputs.version）を
+      # このジョブのチェックアウト内でのみ反映する。コミット・pushは
+      # 行わないためgit historyには影響しない（issue #348）
+      - name: Sync root package.json version for build-time embedding
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+            pkg.version = process.env.RELEASE_VERSION;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
       - name: 🚀 Build and Deploy to GitHub Pages
         id: deploy
         uses: ./.dev-standards-actions/.github/actions/deploy-github-pages


### PR DESCRIPTION
## 背景

PR #340（issue #339）でトップページにバージョン・更新日時を表示する機能を実装したが、root `package.json`の`version`フィールドを更新する仕組みがリリースパイプラインに存在せず、当時手動補正した値（v1.50.1）がその後のリリースで更新されないまま据え置かれていた。実際の最新リリースはv1.51.2まで進んでおり、表示と実態が乖離していた。

Closes #348

## 変更内容

- `cd.yml`の`release`ジョブに、semantic-release実行後のgit tagから実際にリリースされたバージョンを取得する`outputs.version`を追加
- `build-and-deploy-frontend`ジョブで、ビルド直前にこの値をroot `package.json`の`version`フィールドへ反映（このジョブのcheckout内でのみ書き換え、コミット・pushは行わないためgit historyには影響しない）

`frontend/getAppVersionDefine.js`（vite.config.jsからpackage.jsonを読み込みビルド時にdefine埋め込み）はそのまま利用するため、フロントエンド側のコード変更は無い。

## 検討した代替案

`.releaserc.cjs`へ`@semantic-release/npm`＋`@semantic-release/git`を追加し、リポジトリ上のpackage.json自体を更新し続ける案も検討したが、`@semantic-release/git`はbase_branchへの直接pushを試みるため、保護されたブランチではPR経由のフォールバック処理（dev-standardsの`reusable-cd.yml`が実装しているパターン）が別途必要になり、リリースパイプライン本体への変更としてはリスク・変更量が大きいと判断した。今回はビルド成果物にのみ正しい値が埋め込まれればよいため、CDジョブ内でのその場限りの書き換えとした。

## Test plan

- [x] タグ解決ロジック（HEADに新規タグがある場合・無い場合の両方）を疑似gitリポジトリで検証
- [x] package.json書き換えロジックを実際のpackage.jsonのコピー上で実行し、意図通りversionフィールドが更新されることを確認
- [x] 実際にfrontendをビルドし、ビルド成果物にテスト用バージョン文字列が埋め込まれることを確認（確認後package.jsonは元に戻し、コミット対象に含めていない）
- [x] `npm run test`（vitest 41件・lint・build）が成功することを確認
- [ ] マージ後、次回のCD実行でトップページのバージョン表示が実際の最新リリースと一致することを確認する（スマートフォンから確認可能）


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwS9cwB7yYX2W9W6RNcgUa)_